### PR TITLE
Enable `io.popen` on Linux

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,17 @@
 extern crate gcc;
 
+use std::env;
+
 fn main() {
-    gcc::Config::new()
-        .define("LUA_USE_APICHECK", None)
+    let mut config = gcc::Config::new();
+
+    if env::var("CARGO_CFG_TARGET_OS") == Ok("linux".to_string()) {
+        // Among other things, this enables `io.popen` support.
+        // Despite the name, we could enable this on more platforms.
+        config.define("LUA_USE_LINUX", None);
+    }
+
+    config.define("LUA_USE_APICHECK", None)
         .include("lua")
         .file("lua/lapi.c")
         .file("lua/lauxlib.c")

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -1,0 +1,30 @@
+//! This example shows a simple read-evaluate-print-loop (REPL).
+
+extern crate rlua;
+
+use rlua::*;
+use std::io::prelude::*;
+use std::io::{stdin, stdout, stderr, BufReader};
+
+fn main() {
+    let lua = Lua::new();
+    let mut stdout = stdout();
+    let mut stdin = BufReader::new(stdin());
+
+    loop {
+        write!(stdout, "> ").unwrap();
+        stdout.flush().unwrap();
+
+        let mut line = String::new();
+        stdin.read_line(&mut line).unwrap();
+
+        match lua.eval::<LuaMultiValue>(&line) {
+            Ok(values) => {
+                println!("{}", values.iter().map(|value| format!("{:?}", value)).collect::<Vec<_>>().join("\t"));
+            }
+            Err(e) => {
+                writeln!(stderr(), "error: {}", e).unwrap();
+            }
+        }
+    }
+}

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -16,14 +16,24 @@ fn main() {
         stdout.flush().unwrap();
 
         let mut line = String::new();
-        stdin.read_line(&mut line).unwrap();
 
-        match lua.eval::<LuaMultiValue>(&line) {
-            Ok(values) => {
-                println!("{}", values.iter().map(|value| format!("{:?}", value)).collect::<Vec<_>>().join("\t"));
-            }
-            Err(e) => {
-                writeln!(stderr(), "error: {}", e).unwrap();
+        loop {
+            stdin.read_line(&mut line).unwrap();
+
+            match lua.eval::<LuaMultiValue>(&line) {
+                Ok(values) => {
+                    println!("{}", values.iter().map(|value| format!("{:?}", value)).collect::<Vec<_>>().join("\t"));
+                    break;
+                }
+                Err(LuaError(LuaErrorKind::IncompleteStatement(_), _)) => {
+                    // continue reading input and append it to `line`
+                    write!(stdout, ">> ").unwrap();
+                    stdout.flush().unwrap();
+                }
+                Err(e) => {
+                    writeln!(stderr(), "error: {}", e).unwrap();
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
Also adds a REPL example so I could test this :)

Basically, this is a port of https://github.com/tomaka/hlua/pull/132.

Now, there's a few more things we could do. `LUA_USE_LINUX` enables a bit more than just `io.popen`, and it should work fine on a few other OSes, but I didn't bother checking where exactly it is supported.