### PR TITLE
Remove the `Lua*` prefix from most types

### DIFF
--- a/examples/examples.rs
+++ b/examples/examples.rs
@@ -4,7 +4,7 @@ extern crate rlua;
 
 use std::f32;
 
-use rlua::*;
+use rlua::{Lua, Result, Function, Variadic, UserData, UserDataMethods, MetaMethod};
 
 fn examples() -> Result<()> {
     // Create a Lua context with Lua::new().  Eventually, this will allow

--- a/examples/examples.rs
+++ b/examples/examples.rs
@@ -6,7 +6,7 @@ use std::f32;
 
 use rlua::*;
 
-fn examples() -> LuaResult<()> {
+fn examples() -> Result<()> {
     // Create a Lua context with Lua::new().  Eventually, this will allow
     // further control on the lua std library, and will specifically allow
     // limiting Lua to a subset of "safe" functionality.
@@ -56,7 +56,7 @@ fn examples() -> LuaResult<()> {
     let v: i64 = map_table.get("two")?;
     assert_eq!(v, 2);
 
-    // You can pass values like LuaTable back into Lua
+    // You can pass values like Table back into Lua
 
     globals.set("array_table", array_table)?;
     globals.set("map_table", map_table)?;
@@ -76,7 +76,7 @@ fn examples() -> LuaResult<()> {
 
     // You can load lua functions
 
-    let print: LuaFunction = globals.get("print")?;
+    let print: Function = globals.get("print")?;
     print.call::<_, ()>("hello from rust")?;
 
     // This API handles variadics using Heterogeneous Lists.  This is one way to
@@ -90,8 +90,8 @@ fn examples() -> LuaResult<()> {
 
     let check_equal = lua.create_function(|lua, args| {
         // Functions wrapped in lua receive their arguments packed together as
-        // LuaMultiValue.  The first thing that most wrapped functions will do
-        // is "unpack" this LuaMultiValue into its parts.  Due to lifetime type
+        // MultiValue.  The first thing that most wrapped functions will do
+        // is "unpack" this MultiValue into its parts.  Due to lifetime type
         // signature limitations, this cannot be done automatically from the
         // function signature, but this will be fixed with ATCs.  Notice the use
         // of the hlist macros again.
@@ -99,7 +99,7 @@ fn examples() -> LuaResult<()> {
 
         // This function just checks whether two string lists are equal, and in
         // an inefficient way.  Results are returned with lua.pack, which takes
-        // any number of values and turns them back into LuaMultiValue.  In this
+        // any number of values and turns them back into MultiValue.  In this
         // way, multiple values can also be returned to Lua.  Again, this cannot
         // be inferred as part of the function signature due to the same
         // lifetime type signature limitations.
@@ -110,7 +110,7 @@ fn examples() -> LuaResult<()> {
     // You can also accept variadic arguments to rust callbacks.
 
     let join = lua.create_function(|lua, args| {
-        let strings = lua.unpack::<LuaVariadic<String>>(args)?.0;
+        let strings = lua.unpack::<Variadic<String>>(args)?.0;
         // (This is quadratic!, it's just an example!)
         lua.pack(strings.iter().fold("".to_owned(), |a, b| a + b))
     });
@@ -139,14 +139,14 @@ fn examples() -> LuaResult<()> {
     #[derive(Copy, Clone)]
     struct Vec2(f32, f32);
 
-    impl LuaUserDataType for Vec2 {
-        fn add_methods(methods: &mut LuaUserDataMethods<Self>) {
+    impl UserData for Vec2 {
+        fn add_methods(methods: &mut UserDataMethods<Self>) {
             methods.add_method("magnitude", |lua, vec, _| {
                 let mag_squared = vec.0 * vec.0 + vec.1 * vec.1;
                 lua.pack(mag_squared.sqrt())
             });
 
-            methods.add_meta_function(LuaMetaMethod::Add, |lua, params| {
+            methods.add_meta_function(MetaMethod::Add, |lua, params| {
                 let hlist_pat![vec1, vec2] = lua.unpack::<HList![Vec2, Vec2]>(params)?;
                 lua.pack(Vec2(vec1.0 + vec2.0, vec1.1 + vec2.1))
             });

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -2,7 +2,7 @@
 
 extern crate rlua;
 
-use rlua::*;
+use rlua::{Lua, MultiValue, Error};
 use std::io::prelude::*;
 use std::io::{stdin, stdout, stderr, BufReader};
 

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -20,7 +20,7 @@ fn main() {
         loop {
             stdin.read_line(&mut line).unwrap();
 
-            match lua.eval::<LuaMultiValue>(&line, None) {
+            match lua.eval::<MultiValue>(&line, None) {
                 Ok(values) => {
                     println!(
                         "{}",
@@ -32,7 +32,7 @@ fn main() {
                     );
                     break;
                 }
-                Err(LuaError::IncompleteStatement(_)) => {
+                Err(Error::IncompleteStatement(_)) => {
                     // continue reading input and append it to `line`
                     write!(stdout, ">> ").unwrap();
                     stdout.flush().unwrap();

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -4,126 +4,126 @@ use std::hash::Hash;
 use error::*;
 use lua::*;
 
-impl<'lua> ToLua<'lua> for LuaValue<'lua> {
-    fn to_lua(self, _: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
+impl<'lua> ToLua<'lua> for Value<'lua> {
+    fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
         Ok(self)
     }
 }
 
-impl<'lua> FromLua<'lua> for LuaValue<'lua> {
-    fn from_lua(lua_value: LuaValue<'lua>, _: &'lua Lua) -> LuaResult<Self> {
+impl<'lua> FromLua<'lua> for Value<'lua> {
+    fn from_lua(lua_value: Value<'lua>, _: &'lua Lua) -> Result<Self> {
         Ok(lua_value)
     }
 }
 
 impl<'lua> ToLua<'lua> for LuaString<'lua> {
-    fn to_lua(self, _: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
-        Ok(LuaValue::String(self))
+    fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+        Ok(Value::String(self))
     }
 }
 
 impl<'lua> FromLua<'lua> for LuaString<'lua> {
-    fn from_lua(value: LuaValue<'lua>, lua: &'lua Lua) -> LuaResult<LuaString<'lua>> {
+    fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<LuaString<'lua>> {
         lua.coerce_string(value)
     }
 }
 
-impl<'lua> ToLua<'lua> for LuaTable<'lua> {
-    fn to_lua(self, _: &'lua Lua) -> LuaResult<LuaValue> {
-        Ok(LuaValue::Table(self))
+impl<'lua> ToLua<'lua> for Table<'lua> {
+    fn to_lua(self, _: &'lua Lua) -> Result<Value> {
+        Ok(Value::Table(self))
     }
 }
 
-impl<'lua> FromLua<'lua> for LuaTable<'lua> {
-    fn from_lua(value: LuaValue<'lua>, _: &'lua Lua) -> LuaResult<LuaTable<'lua>> {
+impl<'lua> FromLua<'lua> for Table<'lua> {
+    fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<Table<'lua>> {
         match value {
-            LuaValue::Table(table) => Ok(table),
-            _ => Err(LuaError::FromLuaConversionError(
+            Value::Table(table) => Ok(table),
+            _ => Err(Error::FromLuaConversionError(
                 "cannot convert lua value to table".to_owned(),
             )),
         }
     }
 }
 
-impl<'lua> ToLua<'lua> for LuaFunction<'lua> {
-    fn to_lua(self, _: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
-        Ok(LuaValue::Function(self))
+impl<'lua> ToLua<'lua> for Function<'lua> {
+    fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+        Ok(Value::Function(self))
     }
 }
 
-impl<'lua> FromLua<'lua> for LuaFunction<'lua> {
-    fn from_lua(value: LuaValue<'lua>, _: &'lua Lua) -> LuaResult<LuaFunction<'lua>> {
+impl<'lua> FromLua<'lua> for Function<'lua> {
+    fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<Function<'lua>> {
         match value {
-            LuaValue::Function(table) => Ok(table),
-            _ => Err(LuaError::FromLuaConversionError(
+            Value::Function(table) => Ok(table),
+            _ => Err(Error::FromLuaConversionError(
                 "cannot convert lua value to function".to_owned(),
             )),
         }
     }
 }
 
-impl<'lua> ToLua<'lua> for LuaThread<'lua> {
-    fn to_lua(self, _: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
-        Ok(LuaValue::Thread(self))
+impl<'lua> ToLua<'lua> for Thread<'lua> {
+    fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+        Ok(Value::Thread(self))
     }
 }
 
-impl<'lua> FromLua<'lua> for LuaThread<'lua> {
-    fn from_lua(value: LuaValue<'lua>, _: &'lua Lua) -> LuaResult<LuaThread<'lua>> {
+impl<'lua> FromLua<'lua> for Thread<'lua> {
+    fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<Thread<'lua>> {
         match value {
-            LuaValue::Thread(t) => Ok(t),
-            _ => Err(LuaError::FromLuaConversionError(
+            Value::Thread(t) => Ok(t),
+            _ => Err(Error::FromLuaConversionError(
                 "cannot convert lua value to thread".to_owned(),
             )),
         }
     }
 }
 
-impl<'lua> ToLua<'lua> for LuaUserData<'lua> {
-    fn to_lua(self, _: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
-        Ok(LuaValue::UserData(self))
+impl<'lua> ToLua<'lua> for AnyUserData<'lua> {
+    fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+        Ok(Value::UserData(self))
     }
 }
 
-impl<'lua> FromLua<'lua> for LuaUserData<'lua> {
-    fn from_lua(value: LuaValue<'lua>, _: &'lua Lua) -> LuaResult<LuaUserData<'lua>> {
+impl<'lua> FromLua<'lua> for AnyUserData<'lua> {
+    fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<AnyUserData<'lua>> {
         match value {
-            LuaValue::UserData(ud) => Ok(ud),
-            _ => Err(LuaError::FromLuaConversionError(
+            Value::UserData(ud) => Ok(ud),
+            _ => Err(Error::FromLuaConversionError(
                 "cannot convert lua value to userdata".to_owned(),
             )),
         }
     }
 }
 
-impl<'lua, T: LuaUserDataType> ToLua<'lua> for T {
-    fn to_lua(self, lua: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
-        Ok(LuaValue::UserData(lua.create_userdata(self)))
+impl<'lua, T: UserData> ToLua<'lua> for T {
+    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+        Ok(Value::UserData(lua.create_userdata(self)))
     }
 }
 
-impl<'lua, T: LuaUserDataType + Copy> FromLua<'lua> for T {
-    fn from_lua(value: LuaValue<'lua>, _: &'lua Lua) -> LuaResult<T> {
+impl<'lua, T: UserData + Copy> FromLua<'lua> for T {
+    fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<T> {
         match value {
-            LuaValue::UserData(ud) => Ok(*ud.borrow::<T>()?),
-            _ => Err(LuaError::FromLuaConversionError(
+            Value::UserData(ud) => Ok(*ud.borrow::<T>()?),
+            _ => Err(Error::FromLuaConversionError(
                 "cannot convert lua value to userdata".to_owned(),
             )),
         }
     }
 }
 
-impl<'lua> ToLua<'lua> for LuaError {
-    fn to_lua(self, _: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
-        Ok(LuaValue::Error(self))
+impl<'lua> ToLua<'lua> for Error {
+    fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+        Ok(Value::Error(self))
     }
 }
 
-impl<'lua> FromLua<'lua> for LuaError {
-    fn from_lua(value: LuaValue<'lua>, lua: &'lua Lua) -> LuaResult<LuaError> {
+impl<'lua> FromLua<'lua> for Error {
+    fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<Error> {
         match value {
-            LuaValue::Error(err) => Ok(err),
-            val => Ok(LuaError::RuntimeError(
+            Value::Error(err) => Ok(err),
+            val => Ok(Error::RuntimeError(
                 lua.coerce_string(val)
                     .and_then(|s| Ok(s.to_str()?.to_owned()))
                     .unwrap_or_else(|_| "<unprintable error>".to_owned()),
@@ -133,32 +133,32 @@ impl<'lua> FromLua<'lua> for LuaError {
 }
 
 impl<'lua> ToLua<'lua> for bool {
-    fn to_lua(self, _: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
-        Ok(LuaValue::Boolean(self))
+    fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+        Ok(Value::Boolean(self))
     }
 }
 
 impl<'lua> FromLua<'lua> for bool {
-    fn from_lua(v: LuaValue, _: &'lua Lua) -> LuaResult<Self> {
+    fn from_lua(v: Value, _: &'lua Lua) -> Result<Self> {
         match v {
-            LuaValue::Nil => Ok(false),
-            LuaValue::Boolean(b) => Ok(b),
+            Value::Nil => Ok(false),
+            Value::Boolean(b) => Ok(b),
             _ => Ok(true),
         }
     }
 }
 
-impl<'lua> ToLua<'lua> for LuaLightUserData {
-    fn to_lua(self, _: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
-        Ok(LuaValue::LightUserData(self))
+impl<'lua> ToLua<'lua> for LightUserData {
+    fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+        Ok(Value::LightUserData(self))
     }
 }
 
-impl<'lua> FromLua<'lua> for LuaLightUserData {
-    fn from_lua(v: LuaValue, _: &'lua Lua) -> LuaResult<Self> {
+impl<'lua> FromLua<'lua> for LightUserData {
+    fn from_lua(v: Value, _: &'lua Lua) -> Result<Self> {
         match v {
-            LuaValue::LightUserData(ud) => Ok(ud),
-            _ => Err(LuaError::FromLuaConversionError(
+            Value::LightUserData(ud) => Ok(ud),
+            _ => Err(Error::FromLuaConversionError(
                 "cannot convert lua value to lightuserdata".to_owned(),
             )),
         }
@@ -166,33 +166,33 @@ impl<'lua> FromLua<'lua> for LuaLightUserData {
 }
 
 impl<'lua> ToLua<'lua> for String {
-    fn to_lua(self, lua: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
-        Ok(LuaValue::String(lua.create_string(&self)))
+    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+        Ok(Value::String(lua.create_string(&self)))
     }
 }
 
 impl<'lua> FromLua<'lua> for String {
-    fn from_lua(value: LuaValue<'lua>, lua: &'lua Lua) -> LuaResult<Self> {
+    fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<Self> {
         Ok(lua.coerce_string(value)?.to_str()?.to_owned())
     }
 }
 
 impl<'lua, 'a> ToLua<'lua> for &'a str {
-    fn to_lua(self, lua: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
-        Ok(LuaValue::String(lua.create_string(self)))
+    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+        Ok(Value::String(lua.create_string(self)))
     }
 }
 
 macro_rules! lua_convert_int {
     ($x: ty) => {
         impl<'lua> ToLua<'lua> for $x {
-            fn to_lua(self, _: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
-                Ok(LuaValue::Integer(self as LuaInteger))
+            fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+                Ok(Value::Integer(self as Integer))
             }
         }
 
         impl<'lua> FromLua<'lua> for $x {
-            fn from_lua(value: LuaValue<'lua>, lua: &'lua Lua) -> LuaResult<Self> {
+            fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<Self> {
                 Ok(lua.coerce_integer(value)? as $x)
             }
         }
@@ -213,13 +213,13 @@ lua_convert_int!(usize);
 macro_rules! lua_convert_float {
     ($x: ty) => {
         impl<'lua> ToLua<'lua> for $x {
-            fn to_lua(self, _: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
-                Ok(LuaValue::Number(self as LuaNumber))
+            fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+                Ok(Value::Number(self as Number))
             }
         }
 
         impl<'lua> FromLua<'lua> for $x {
-            fn from_lua(value: LuaValue<'lua>, lua: &'lua Lua) -> LuaResult<Self> {
+            fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<Self> {
                 Ok(lua.coerce_number(value)? as $x)
             }
         }
@@ -230,17 +230,17 @@ lua_convert_float!(f32);
 lua_convert_float!(f64);
 
 impl<'lua, T: ToLua<'lua>> ToLua<'lua> for Vec<T> {
-    fn to_lua(self, lua: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
-        Ok(LuaValue::Table(lua.create_sequence_from(self)?))
+    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+        Ok(Value::Table(lua.create_sequence_from(self)?))
     }
 }
 
 impl<'lua, T: FromLua<'lua>> FromLua<'lua> for Vec<T> {
-    fn from_lua(value: LuaValue<'lua>, _: &'lua Lua) -> LuaResult<Self> {
-        if let LuaValue::Table(table) = value {
+    fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<Self> {
+        if let Value::Table(table) = value {
             table.sequence_values().collect()
         } else {
-            Err(LuaError::FromLuaConversionError(
+            Err(Error::FromLuaConversionError(
                 "cannot convert lua value to table for Vec".to_owned(),
             ))
         }
@@ -248,17 +248,17 @@ impl<'lua, T: FromLua<'lua>> FromLua<'lua> for Vec<T> {
 }
 
 impl<'lua, K: Eq + Hash + ToLua<'lua>, V: ToLua<'lua>> ToLua<'lua> for HashMap<K, V> {
-    fn to_lua(self, lua: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
-        Ok(LuaValue::Table(lua.create_table_from(self)?))
+    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+        Ok(Value::Table(lua.create_table_from(self)?))
     }
 }
 
 impl<'lua, K: Eq + Hash + FromLua<'lua>, V: FromLua<'lua>> FromLua<'lua> for HashMap<K, V> {
-    fn from_lua(value: LuaValue<'lua>, _: &'lua Lua) -> LuaResult<Self> {
-        if let LuaValue::Table(table) = value {
+    fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<Self> {
+        if let Value::Table(table) = value {
             table.pairs().collect()
         } else {
-            Err(LuaError::FromLuaConversionError(
+            Err(Error::FromLuaConversionError(
                 "cannot convert lua value to table for HashMap".to_owned(),
             ))
         }
@@ -266,17 +266,17 @@ impl<'lua, K: Eq + Hash + FromLua<'lua>, V: FromLua<'lua>> FromLua<'lua> for Has
 }
 
 impl<'lua, K: Ord + ToLua<'lua>, V: ToLua<'lua>> ToLua<'lua> for BTreeMap<K, V> {
-    fn to_lua(self, lua: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
-        Ok(LuaValue::Table(lua.create_table_from(self)?))
+    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+        Ok(Value::Table(lua.create_table_from(self)?))
     }
 }
 
 impl<'lua, K: Ord + FromLua<'lua>, V: FromLua<'lua>> FromLua<'lua> for BTreeMap<K, V> {
-    fn from_lua(value: LuaValue<'lua>, _: &'lua Lua) -> LuaResult<Self> {
-        if let LuaValue::Table(table) = value {
+    fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<Self> {
+        if let Value::Table(table) = value {
             table.pairs().collect()
         } else {
-            Err(LuaError::FromLuaConversionError(
+            Err(Error::FromLuaConversionError(
                 "cannot convert lua value to table for BTreeMap".to_owned(),
             ))
         }
@@ -284,7 +284,7 @@ impl<'lua, K: Ord + FromLua<'lua>, V: FromLua<'lua>> FromLua<'lua> for BTreeMap<
 }
 
 impl<'lua, T: ToLua<'lua>> ToLua<'lua> for Option<T> {
-    fn to_lua(self, lua: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
+    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
         match self {
             Some(val) => val.to_lua(lua),
             None => Ok(LuaNil),
@@ -293,7 +293,7 @@ impl<'lua, T: ToLua<'lua>> ToLua<'lua> for Option<T> {
 }
 
 impl<'lua, T: FromLua<'lua>> FromLua<'lua> for Option<T> {
-    fn from_lua(value: LuaValue<'lua>, lua: &'lua Lua) -> LuaResult<Self> {
+    fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<Self> {
         match value {
             LuaNil => Ok(None),
             value => Ok(Some(T::from_lua(value, lua)?)),

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, BTreeMap};
 use std::hash::Hash;
+use std::string::String as StdString;
 
 use error::*;
 use lua::*;
@@ -16,14 +17,14 @@ impl<'lua> FromLua<'lua> for Value<'lua> {
     }
 }
 
-impl<'lua> ToLua<'lua> for LuaString<'lua> {
+impl<'lua> ToLua<'lua> for String<'lua> {
     fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
         Ok(Value::String(self))
     }
 }
 
-impl<'lua> FromLua<'lua> for LuaString<'lua> {
-    fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<LuaString<'lua>> {
+impl<'lua> FromLua<'lua> for String<'lua> {
+    fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<String<'lua>> {
         lua.coerce_string(value)
     }
 }
@@ -165,13 +166,13 @@ impl<'lua> FromLua<'lua> for LightUserData {
     }
 }
 
-impl<'lua> ToLua<'lua> for String {
+impl<'lua> ToLua<'lua> for StdString {
     fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
         Ok(Value::String(lua.create_string(&self)))
     }
 }
 
-impl<'lua> FromLua<'lua> for String {
+impl<'lua> FromLua<'lua> for StdString {
     fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<Self> {
         Ok(lua.coerce_string(value)?.to_str()?.to_owned())
     }

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -288,7 +288,7 @@ impl<'lua, T: ToLua<'lua>> ToLua<'lua> for Option<T> {
     fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
         match self {
             Some(val) => val.to_lua(lua),
-            None => Ok(LuaNil),
+            None => Ok(Nil),
         }
     }
 }
@@ -296,7 +296,7 @@ impl<'lua, T: ToLua<'lua>> ToLua<'lua> for Option<T> {
 impl<'lua, T: FromLua<'lua>> FromLua<'lua> for Option<T> {
     fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<Self> {
         match value {
-            LuaNil => Ok(None),
+            Nil => Ok(None),
             value => Ok(Some(T::from_lua(value, lua)?)),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,11 +18,11 @@ pub enum Error {
     FromLuaConversionError(String),
     /// A `Thread` was resumed and the coroutine was no longer active.
     CoroutineInactive,
-    /// A `LuaUserData` is not the expected type in a borrow.
+    /// An `AnyUserData` is not the expected type in a borrow.
     UserDataTypeMismatch,
-    /// A `LuaUserData` immutable borrow failed because it is already borrowed mutably.
+    /// An `AnyUserData` immutable borrow failed because it is already borrowed mutably.
     UserDataBorrowError,
-    /// A `LuaUserData` mutable borrow failed because it is already borrowed.
+    /// An `AnyUserData` mutable borrow failed because it is already borrowed.
     UserDataBorrowMutError,
     /// Lua error that originated as a Error in a callback.  The first field is the lua error as
     /// a string, the second field is the Arc holding the original Error.

--- a/src/error.rs
+++ b/src/error.rs
@@ -94,11 +94,11 @@ impl Error {
     }
 }
 
-pub trait LuaExternalError {
+pub trait ExternalError {
     fn to_lua_err(self) -> Error;
 }
 
-impl<E> LuaExternalError for E
+impl<E> ExternalError for E
 where
     E: Into<Box<error::Error + Send + Sync>>,
 {
@@ -122,13 +122,13 @@ where
     }
 }
 
-pub trait LuaExternalResult<T> {
+pub trait ExternalResult<T> {
     fn to_lua_err(self) -> Result<T>;
 }
 
-impl<T, E> LuaExternalResult<T> for ::std::result::Result<T, E>
+impl<T, E> ExternalResult<T> for ::std::result::Result<T, E>
 where
-    E: LuaExternalError,
+    E: ExternalError,
 {
     fn to_lua_err(self) -> Result<T> {
         self.map_err(|e| e.to_lua_err())

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,9 @@
 use std::fmt;
 use std::sync::Arc;
-use std::result::Result;
-use std::error::Error;
+use std::error;
 
 #[derive(Debug, Clone)]
-pub enum LuaError {
+pub enum Error {
     /// Lua syntax error, aka `LUA_ERRSYNTAX` that is NOT an incomplete statement.
     SyntaxError(String),
     /// Lua syntax error that IS an incomplete statement.  Useful for implementing a REPL.
@@ -17,7 +16,7 @@ pub enum LuaError {
     ToLuaConversionError(String),
     /// A generic Lua -> Rust conversion error.
     FromLuaConversionError(String),
-    /// A `LuaThread` was resumed and the coroutine was no longer active.
+    /// A `Thread` was resumed and the coroutine was no longer active.
     CoroutineInactive,
     /// A `LuaUserData` is not the expected type in a borrow.
     UserDataTypeMismatch,
@@ -25,87 +24,87 @@ pub enum LuaError {
     UserDataBorrowError,
     /// A `LuaUserData` mutable borrow failed because it is already borrowed.
     UserDataBorrowMutError,
-    /// Lua error that originated as a LuaError in a callback.  The first field is the lua error as
-    /// a string, the second field is the Arc holding the original LuaError.
-    CallbackError(String, Arc<LuaError>),
+    /// Lua error that originated as a Error in a callback.  The first field is the lua error as
+    /// a string, the second field is the Arc holding the original Error.
+    CallbackError(String, Arc<Error>),
     /// Any custom external error type, mostly useful for returning external error types from
     /// callbacks.
-    ExternalError(Arc<Error + Send + Sync>),
+    ExternalError(Arc<error::Error + Send + Sync>),
 }
 
-pub type LuaResult<T> = Result<T, LuaError>;
+pub type Result<T> = ::std::result::Result<T, Error>;
 
-impl fmt::Display for LuaError {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match self {
-            &LuaError::SyntaxError(ref msg) => write!(fmt, "Lua syntax error: {}", msg),
-            &LuaError::IncompleteStatement(ref msg) => {
+impl fmt::Display for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::SyntaxError(ref msg) => write!(fmt, "Lua syntax error: {}", msg),
+            Error::IncompleteStatement(ref msg) => {
                 write!(fmt, "Lua syntax error (incomplete statement): {}", msg)
             }
-            &LuaError::RuntimeError(ref msg) => write!(fmt, "Lua runtime error: {}", msg),
-            &LuaError::ErrorError(ref msg) => write!(fmt, "Lua error in error handler: {}", msg),
-            &LuaError::ToLuaConversionError(ref msg) => {
+            Error::RuntimeError(ref msg) => write!(fmt, "Lua runtime error: {}", msg),
+            Error::ErrorError(ref msg) => write!(fmt, "Lua error in error handler: {}", msg),
+            Error::ToLuaConversionError(ref msg) => {
                 write!(fmt, "Error converting rust type to lua: {}", msg)
             }
-            &LuaError::FromLuaConversionError(ref msg) => {
+            Error::FromLuaConversionError(ref msg) => {
                 write!(fmt, "Error converting lua type to rust: {}", msg)
             }
-            &LuaError::CoroutineInactive => write!(fmt, "Cannot resume inactive coroutine"),
-            &LuaError::UserDataTypeMismatch => write!(fmt, "Userdata not expected type"),
-            &LuaError::UserDataBorrowError => write!(fmt, "Userdata already mutably borrowed"),
-            &LuaError::UserDataBorrowMutError => write!(fmt, "Userdata already borrowed"),
-            &LuaError::CallbackError(ref msg, _) => {
+            Error::CoroutineInactive => write!(fmt, "Cannot resume inactive coroutine"),
+            Error::UserDataTypeMismatch => write!(fmt, "Userdata not expected type"),
+            Error::UserDataBorrowError => write!(fmt, "Userdata already mutably borrowed"),
+            Error::UserDataBorrowMutError => write!(fmt, "Userdata already borrowed"),
+            Error::CallbackError(ref msg, _) => {
                 write!(fmt, "Error during lua callback: {}", msg)
             }
-            &LuaError::ExternalError(ref err) => err.fmt(fmt),
+            Error::ExternalError(ref err) => err.fmt(fmt),
         }
     }
 }
 
-impl Error for LuaError {
+impl error::Error for Error {
     fn description(&self) -> &str {
-        match self {
-            &LuaError::SyntaxError(_) => "lua syntax error",
-            &LuaError::IncompleteStatement(_) => "lua incomplete statement",
-            &LuaError::RuntimeError(_) => "lua runtime error",
-            &LuaError::ErrorError(_) => "lua error handling error",
-            &LuaError::ToLuaConversionError(_) => "conversion error to lua",
-            &LuaError::FromLuaConversionError(_) => "conversion error from lua",
-            &LuaError::CoroutineInactive => "lua coroutine inactive",
-            &LuaError::UserDataTypeMismatch => "lua userdata type mismatch",
-            &LuaError::UserDataBorrowError => "lua userdata already mutably borrowed",
-            &LuaError::UserDataBorrowMutError => "lua userdata already borrowed",
-            &LuaError::CallbackError(_, _) => "lua callback error",
-            &LuaError::ExternalError(ref err) => err.description(),
+        match *self {
+            Error::SyntaxError(_) => "lua syntax error",
+            Error::IncompleteStatement(_) => "lua incomplete statement",
+            Error::RuntimeError(_) => "lua runtime error",
+            Error::ErrorError(_) => "lua error handling error",
+            Error::ToLuaConversionError(_) => "conversion error to lua",
+            Error::FromLuaConversionError(_) => "conversion error from lua",
+            Error::CoroutineInactive => "lua coroutine inactive",
+            Error::UserDataTypeMismatch => "lua userdata type mismatch",
+            Error::UserDataBorrowError => "lua userdata already mutably borrowed",
+            Error::UserDataBorrowMutError => "lua userdata already borrowed",
+            Error::CallbackError(_, _) => "lua callback error",
+            Error::ExternalError(ref err) => err.description(),
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
-        match self {
-            &LuaError::CallbackError(_, ref cause) => Some(cause.as_ref()),
-            &LuaError::ExternalError(ref err) => err.cause(),
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::CallbackError(_, ref cause) => Some(cause.as_ref()),
+            Error::ExternalError(ref err) => err.cause(),
             _ => None,
         }
     }
 }
 
-impl LuaError {
-    pub fn external<T: 'static + Error + Send + Sync>(err: T) -> LuaError {
-        LuaError::ExternalError(Arc::new(err))
+impl Error {
+    pub fn external<T: 'static + error::Error + Send + Sync>(err: T) -> Error {
+        Error::ExternalError(Arc::new(err))
     }
 }
 
 pub trait LuaExternalError {
-    fn to_lua_err(self) -> LuaError;
+    fn to_lua_err(self) -> Error;
 }
 
 impl<E> LuaExternalError for E
 where
-    E: Into<Box<Error + Send + Sync>>,
+    E: Into<Box<error::Error + Send + Sync>>,
 {
-    fn to_lua_err(self) -> LuaError {
+    fn to_lua_err(self) -> Error {
         #[derive(Debug)]
-        struct WrapError(Box<Error + Send + Sync>);
+        struct WrapError(Box<error::Error + Send + Sync>);
 
         impl fmt::Display for WrapError {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -113,25 +112,25 @@ where
             }
         }
 
-        impl Error for WrapError {
+        impl error::Error for WrapError {
             fn description(&self) -> &str {
                 self.0.description()
             }
         }
 
-        LuaError::external(WrapError(self.into()))
+        Error::external(WrapError(self.into()))
     }
 }
 
 pub trait LuaExternalResult<T> {
-    fn to_lua_err(self) -> LuaResult<T>;
+    fn to_lua_err(self) -> Result<T>;
 }
 
-impl<T, E> LuaExternalResult<T> for Result<T, E>
+impl<T, E> LuaExternalResult<T> for ::std::result::Result<T, E>
 where
     E: LuaExternalError,
 {
-    fn to_lua_err(self) -> LuaResult<T> {
+    fn to_lua_err(self) -> Result<T> {
         self.map_err(|e| e.to_lua_err())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,10 @@ mod multi;
 #[cfg(test)]
 mod tests;
 
-pub use error::*;
-pub use lua::*;
-pub use multi::*;
+pub use error::{Error, Result, ExternalError, ExternalResult};
+pub use lua::{Value, Nil, ToLua, FromLua, MultiValue, ToLuaMulti, FromLuaMulti, Integer, Number,
+              LightUserData, String, Table, TablePairs, TableSequence, Function, ThreadStatus,
+              Thread, MetaMethod, UserDataMethods, UserData, AnyUserData, Lua};
+pub use multi::Variadic;
+
+pub mod prelude;

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -16,85 +16,85 @@ use util::*;
 
 /// A dynamically typed Lua value.
 #[derive(Debug, Clone)]
-pub enum LuaValue<'lua> {
+pub enum Value<'lua> {
     /// The Lua value `nil`.
     Nil,
     /// The Lua value `true` or `false`.
     Boolean(bool),
     /// A "light userdata" object, equivalent to a raw pointer.
-    LightUserData(LuaLightUserData),
+    LightUserData(LightUserData),
     /// An integer number.
     ///
-    /// Any Lua number convertible to a `LuaInteger` will be represented as this variant.
-    Integer(LuaInteger),
+    /// Any Lua number convertible to a `Integer` will be represented as this variant.
+    Integer(Integer),
     /// A floating point number.
-    Number(LuaNumber),
+    Number(Number),
     /// An interned string, managed by Lua.
     ///
     /// Unlike Rust strings, Lua strings may not be valid UTF-8.
     String(LuaString<'lua>),
     /// Reference to a Lua table.
-    Table(LuaTable<'lua>),
+    Table(Table<'lua>),
     /// Reference to a Lua function (or closure).
-    Function(LuaFunction<'lua>),
+    Function(Function<'lua>),
     /// Reference to a Lua thread (or coroutine).
-    Thread(LuaThread<'lua>),
+    Thread(Thread<'lua>),
     /// Reference to a userdata object that holds a custom type which implements
-    /// `LuaUserDataType`.  Special builtin userdata types will be represented as
-    /// other `LuaValue` variants.
-    UserData(LuaUserData<'lua>),
-    /// `LuaError` is a special builtin userdata type.  When received from Lua
+    /// `UserData`.  Special builtin userdata types will be represented as
+    /// other `Value` variants.
+    UserData(AnyUserData<'lua>),
+    /// `Error` is a special builtin userdata type.  When received from Lua
     /// it is implicitly cloned.
-    Error(LuaError),
+    Error(Error),
 }
-pub use self::LuaValue::Nil as LuaNil;
+pub use self::Value::Nil as LuaNil;
 
-/// Trait for types convertible to `LuaValue`.
+/// Trait for types convertible to `Value`.
 pub trait ToLua<'a> {
     /// Performs the conversion.
-    fn to_lua(self, lua: &'a Lua) -> LuaResult<LuaValue<'a>>;
+    fn to_lua(self, lua: &'a Lua) -> Result<Value<'a>>;
 }
 
-/// Trait for types convertible from `LuaValue`.
+/// Trait for types convertible from `Value`.
 pub trait FromLua<'a>: Sized {
     /// Performs the conversion.
-    fn from_lua(lua_value: LuaValue<'a>, lua: &'a Lua) -> LuaResult<Self>;
+    fn from_lua(lua_value: Value<'a>, lua: &'a Lua) -> Result<Self>;
 }
 
 /// Multiple Lua values used for both argument passing and also for multiple return values.
 #[derive(Debug, Clone)]
-pub struct LuaMultiValue<'lua>(VecDeque<LuaValue<'lua>>);
+pub struct MultiValue<'lua>(VecDeque<Value<'lua>>);
 
-impl<'lua> LuaMultiValue<'lua> {
-    pub fn new() -> LuaMultiValue<'lua> {
-        LuaMultiValue(VecDeque::new())
+impl<'lua> MultiValue<'lua> {
+    pub fn new() -> MultiValue<'lua> {
+        MultiValue(VecDeque::new())
     }
 }
 
-impl<'lua> FromIterator<LuaValue<'lua>> for LuaMultiValue<'lua> {
-    fn from_iter<I: IntoIterator<Item = LuaValue<'lua>>>(iter: I) -> Self {
-        LuaMultiValue(VecDeque::from_iter(iter))
+impl<'lua> FromIterator<Value<'lua>> for MultiValue<'lua> {
+    fn from_iter<I: IntoIterator<Item = Value<'lua>>>(iter: I) -> Self {
+        MultiValue(VecDeque::from_iter(iter))
     }
 }
 
-impl<'lua> IntoIterator for LuaMultiValue<'lua> {
-    type Item = LuaValue<'lua>;
-    type IntoIter = <VecDeque<LuaValue<'lua>> as IntoIterator>::IntoIter;
+impl<'lua> IntoIterator for MultiValue<'lua> {
+    type Item = Value<'lua>;
+    type IntoIter = <VecDeque<Value<'lua>> as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
     }
 }
 
-impl<'lua> Deref for LuaMultiValue<'lua> {
-    type Target = VecDeque<LuaValue<'lua>>;
+impl<'lua> Deref for MultiValue<'lua> {
+    type Target = VecDeque<Value<'lua>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'lua> DerefMut for LuaMultiValue<'lua> {
+impl<'lua> DerefMut for MultiValue<'lua> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
@@ -106,7 +106,7 @@ impl<'lua> DerefMut for LuaMultiValue<'lua> {
 /// one. Any type that implements `ToLua` will automatically implement this trait.
 pub trait ToLuaMulti<'a> {
     /// Performs the conversion.
-    fn to_lua_multi(self, lua: &'a Lua) -> LuaResult<LuaMultiValue<'a>>;
+    fn to_lua_multi(self, lua: &'a Lua) -> Result<MultiValue<'a>>;
 }
 
 /// Trait for types that can be created from an arbitrary number of Lua values.
@@ -120,11 +120,11 @@ pub trait FromLuaMulti<'a>: Sized {
     /// values should be ignored. This reflects the semantics of Lua when calling a function or
     /// assigning values. Similarly, if not enough values are given, conversions should assume that
     /// any missing values are nil.
-    fn from_lua_multi(values: LuaMultiValue<'a>, lua: &'a Lua) -> LuaResult<Self>;
+    fn from_lua_multi(values: MultiValue<'a>, lua: &'a Lua) -> Result<Self>;
 }
 
 type LuaCallback<'lua> = Box<
-    FnMut(&'lua Lua, LuaMultiValue<'lua>) -> LuaResult<LuaMultiValue<'lua>>
+    FnMut(&'lua Lua, MultiValue<'lua>) -> Result<MultiValue<'lua>>
         + 'lua,
 >;
 
@@ -157,13 +157,13 @@ impl<'lua> Drop for LuaRef<'lua> {
 }
 
 /// Type of Lua integer numbers.
-pub type LuaInteger = ffi::lua_Integer;
+pub type Integer = ffi::lua_Integer;
 /// Type of Lua floating point numbers.
-pub type LuaNumber = ffi::lua_Number;
+pub type Number = ffi::lua_Number;
 
 /// A "light" userdata value. Equivalent to an unmanaged raw pointer.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct LuaLightUserData(pub *mut c_void);
+pub struct LightUserData(pub *mut c_void);
 
 /// Handle to an internal Lua string.
 ///
@@ -190,7 +190,7 @@ impl<'lua> LuaString<'lua> {
     /// assert!(non_utf8.to_str().is_err());
     /// # }
     /// ```
-    pub fn to_str(&self) -> LuaResult<&str> {
+    pub fn to_str(&self) -> Result<&str> {
         let lua = self.0.lua;
         unsafe {
             stack_err_guard(lua.state, 0, || {
@@ -199,7 +199,7 @@ impl<'lua> LuaString<'lua> {
                 assert_eq!(ffi::lua_type(lua.state, -1), ffi::LUA_TSTRING);
                 let s = CStr::from_ptr(ffi::lua_tostring(lua.state, -1))
                     .to_str()
-                    .map_err(|e| LuaError::FromLuaConversionError(e.to_string()))?;
+                    .map_err(|e| Error::FromLuaConversionError(e.to_string()))?;
                 ffi::lua_pop(lua.state, 1);
                 Ok(s)
             })
@@ -209,16 +209,16 @@ impl<'lua> LuaString<'lua> {
 
 /// Handle to an internal Lua table.
 #[derive(Clone, Debug)]
-pub struct LuaTable<'lua>(LuaRef<'lua>);
+pub struct Table<'lua>(LuaRef<'lua>);
 
-impl<'lua> LuaTable<'lua> {
+impl<'lua> Table<'lua> {
     /// Sets a key-value pair in the table.
     ///
     /// If the value is `nil`, this will effectively remove the pair.
     ///
     /// This might invoke the `__newindex` metamethod. Use the `raw_set` method if that is not
     /// desired.
-    pub fn set<K: ToLua<'lua>, V: ToLua<'lua>>(&self, key: K, value: V) -> LuaResult<()> {
+    pub fn set<K: ToLua<'lua>, V: ToLua<'lua>>(&self, key: K, value: V) -> Result<()> {
         let lua = self.0.lua;
         let key = key.to_lua(lua)?;
         let value = value.to_lua(lua)?;
@@ -241,7 +241,7 @@ impl<'lua> LuaTable<'lua> {
     /// If no value is associated to `key`, returns the `nil` value.
     ///
     /// This might invoke the `__index` metamethod. Use the `raw_get` method if that is not desired.
-    pub fn get<K: ToLua<'lua>, V: FromLua<'lua>>(&self, key: K) -> LuaResult<V> {
+    pub fn get<K: ToLua<'lua>, V: FromLua<'lua>>(&self, key: K) -> Result<V> {
         let lua = self.0.lua;
         let key = key.to_lua(lua)?;
         unsafe {
@@ -259,7 +259,7 @@ impl<'lua> LuaTable<'lua> {
     }
 
     /// Checks whether the table contains a non-nil value for `key`.
-    pub fn contains_key<K: ToLua<'lua>>(&self, key: K) -> LuaResult<bool> {
+    pub fn contains_key<K: ToLua<'lua>>(&self, key: K) -> Result<bool> {
         let lua = self.0.lua;
         let key = key.to_lua(lua)?;
         unsafe {
@@ -277,7 +277,7 @@ impl<'lua> LuaTable<'lua> {
     }
 
     /// Sets a key-value pair without invoking metamethods.
-    pub fn raw_set<K: ToLua<'lua>, V: ToLua<'lua>>(&self, key: K, value: V) -> LuaResult<()> {
+    pub fn raw_set<K: ToLua<'lua>, V: ToLua<'lua>>(&self, key: K, value: V) -> Result<()> {
         let lua = self.0.lua;
         unsafe {
             stack_err_guard(lua.state, 0, || {
@@ -293,7 +293,7 @@ impl<'lua> LuaTable<'lua> {
     }
 
     /// Gets the value associated to `key` without invoking metamethods.
-    pub fn raw_get<K: ToLua<'lua>, V: FromLua<'lua>>(&self, key: K) -> LuaResult<V> {
+    pub fn raw_get<K: ToLua<'lua>, V: FromLua<'lua>>(&self, key: K) -> Result<V> {
         let lua = self.0.lua;
         unsafe {
             stack_err_guard(lua.state, 0, || {
@@ -311,7 +311,7 @@ impl<'lua> LuaTable<'lua> {
     /// Returns the result of the Lua `#` operator.
     ///
     /// This might invoke the `__len` metamethod. Use the `raw_len` method if that is not desired.
-    pub fn len(&self) -> LuaResult<LuaInteger> {
+    pub fn len(&self) -> Result<Integer> {
         let lua = self.0.lua;
         unsafe {
             check_stack(lua.state, 3);
@@ -325,7 +325,7 @@ impl<'lua> LuaTable<'lua> {
     }
 
     /// Returns the result of the Lua `#` operator, without invoking the `__len` metamethod.
-    pub fn raw_len(&self) -> LuaInteger {
+    pub fn raw_len(&self) -> Integer {
         let lua = self.0.lua;
         unsafe {
             stack_guard(lua.state, 0, || {
@@ -333,20 +333,20 @@ impl<'lua> LuaTable<'lua> {
                 lua.push_ref(lua.state, &self.0);
                 let len = ffi::lua_rawlen(lua.state, -1);
                 ffi::lua_pop(lua.state, 1);
-                len as LuaInteger
+                len as Integer
             })
         }
     }
 
     /// Consume this table and return an iterator over the pairs of the table, works like the Lua
     /// 'pairs' function.
-    pub fn pairs<K: FromLua<'lua>, V: FromLua<'lua>>(self) -> LuaTablePairs<'lua, K, V> {
+    pub fn pairs<K: FromLua<'lua>, V: FromLua<'lua>>(self) -> TablePairs<'lua, K, V> {
         let next_key = Some(LuaRef {
             lua: self.0.lua,
             registry_id: ffi::LUA_REFNIL,
         });
 
-        LuaTablePairs {
+        TablePairs {
             table: self.0,
             next_key,
             _phantom: PhantomData,
@@ -356,8 +356,8 @@ impl<'lua> LuaTable<'lua> {
     /// Consume this table and return an iterator over the values of this table, which should be a
     /// sequence.  Works like the Lua 'ipairs' function, but doesn't return the indexes, only the
     /// values in order.
-    pub fn sequence_values<V: FromLua<'lua>>(self) -> LuaTableSequence<'lua, V> {
-        LuaTableSequence {
+    pub fn sequence_values<V: FromLua<'lua>>(self) -> TableSequence<'lua, V> {
+        TableSequence {
             table: self.0,
             index: Some(1),
             _phantom: PhantomData,
@@ -368,18 +368,18 @@ impl<'lua> LuaTable<'lua> {
 /// An iterator over the pairs of a Lua table.
 ///
 /// Should behave exactly like the lua 'pairs' function.  Holds an internal reference to the table.
-pub struct LuaTablePairs<'lua, K, V> {
+pub struct TablePairs<'lua, K, V> {
     table: LuaRef<'lua>,
     next_key: Option<LuaRef<'lua>>,
     _phantom: PhantomData<(K, V)>,
 }
 
-impl<'lua, K, V> Iterator for LuaTablePairs<'lua, K, V>
+impl<'lua, K, V> Iterator for TablePairs<'lua, K, V>
 where
     K: FromLua<'lua>,
     V: FromLua<'lua>,
 {
-    type Item = LuaResult<(K, V)>;
+    type Item = Result<(K, V)>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(next_key) = self.next_key.take() {
@@ -422,17 +422,17 @@ where
 ///
 /// Should behave similarly to the lua 'ipairs" function, except only produces the values, not the
 /// indexes.  Holds an internal reference to the table.
-pub struct LuaTableSequence<'lua, V> {
+pub struct TableSequence<'lua, V> {
     table: LuaRef<'lua>,
-    index: Option<LuaInteger>,
+    index: Option<Integer>,
     _phantom: PhantomData<V>,
 }
 
-impl<'lua, V> Iterator for LuaTableSequence<'lua, V>
+impl<'lua, V> Iterator for TableSequence<'lua, V>
 where
     V: FromLua<'lua>,
 {
-    type Item = LuaResult<V>;
+    type Item = Result<V>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(index) = self.index.take() {
@@ -464,13 +464,13 @@ where
 
 /// Handle to an internal Lua function.
 #[derive(Clone, Debug)]
-pub struct LuaFunction<'lua>(LuaRef<'lua>);
+pub struct Function<'lua>(LuaRef<'lua>);
 
-impl<'lua> LuaFunction<'lua> {
+impl<'lua> Function<'lua> {
     /// Calls the function, passing `args` as function arguments.
     ///
     /// The function's return values are converted to the generic type `R`.
-    pub fn call<A: ToLuaMulti<'lua>, R: FromLuaMulti<'lua>>(&self, args: A) -> LuaResult<R> {
+    pub fn call<A: ToLuaMulti<'lua>, R: FromLuaMulti<'lua>>(&self, args: A) -> Result<R> {
         let lua = self.0.lua;
         unsafe {
             stack_err_guard(lua.state, 0, || {
@@ -488,7 +488,7 @@ impl<'lua> LuaFunction<'lua> {
                     pcall_with_traceback(lua.state, nargs, ffi::LUA_MULTRET),
                 )?;
                 let nresults = ffi::lua_gettop(lua.state) - stack_start;
-                let mut results = LuaMultiValue::new();
+                let mut results = MultiValue::new();
                 for _ in 0..nresults {
                     results.push_front(lua.pop_value(lua.state));
                 }
@@ -519,15 +519,15 @@ impl<'lua> LuaFunction<'lua> {
     /// let globals = lua.globals();
     ///
     /// // Bind the argument `123` to Lua's `tostring` function
-    /// let tostring: LuaFunction = globals.get("tostring").unwrap();
-    /// let tostring_123: LuaFunction = tostring.bind(123i32).unwrap();
+    /// let tostring: Function = globals.get("tostring").unwrap();
+    /// let tostring_123: Function = tostring.bind(123i32).unwrap();
     ///
     /// // Now we can call `tostring_123` without arguments to get the result of `tostring(123)`
     /// let result: String = tostring_123.call(()).unwrap();
     /// assert_eq!(result, "123");
     /// # }
     /// ```
-    pub fn bind<A: ToLuaMulti<'lua>>(&self, args: A) -> LuaResult<LuaFunction<'lua>> {
+    pub fn bind<A: ToLuaMulti<'lua>>(&self, args: A) -> Result<Function<'lua>> {
         unsafe extern "C" fn bind_call_impl(state: *mut ffi::lua_State) -> c_int {
             let nargs = ffi::lua_gettop(state);
 
@@ -562,7 +562,7 @@ impl<'lua> LuaFunction<'lua> {
 
                 ffi::lua_pushcclosure(lua.state, bind_call_impl, nargs + 2);
 
-                Ok(LuaFunction(lua.pop_ref(lua.state)))
+                Ok(Function(lua.pop_ref(lua.state)))
             })
         }
     }
@@ -570,10 +570,10 @@ impl<'lua> LuaFunction<'lua> {
 
 /// Status of a Lua thread (or coroutine).
 ///
-/// A `LuaThread` is `Active` before the coroutine function finishes, Dead after it finishes, and in
+/// A `Thread` is `Active` before the coroutine function finishes, Dead after it finishes, and in
 /// Error state if error has been called inside the coroutine.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum LuaThreadStatus {
+pub enum ThreadStatus {
     /// The thread has finished executing.
     Dead,
     /// The thread is currently running or suspended because it has called `coroutine.yield`.
@@ -584,9 +584,9 @@ pub enum LuaThreadStatus {
 
 /// Handle to an internal Lua thread (or coroutine).
 #[derive(Clone, Debug)]
-pub struct LuaThread<'lua>(LuaRef<'lua>);
+pub struct Thread<'lua>(LuaRef<'lua>);
 
-impl<'lua> LuaThread<'lua> {
+impl<'lua> Thread<'lua> {
     /// Resumes execution of this thread.
     ///
     /// Equivalent to `coroutine.resume`.
@@ -610,7 +610,7 @@ impl<'lua> LuaThread<'lua> {
     ///
     /// # fn main() {
     /// let lua = Lua::new();
-    /// let thread: LuaThread = lua.eval(r#"
+    /// let thread: Thread = lua.eval(r#"
     ///     coroutine.create(function(arg)
     ///         assert(arg == 42)
     ///         local yieldarg = coroutine.yield(123)
@@ -624,12 +624,12 @@ impl<'lua> LuaThread<'lua> {
     ///
     /// // The coroutine has now returned, so `resume` will fail
     /// match thread.resume::<_, u32>(()) {
-    ///     Err(LuaError::CoroutineInactive) => {},
+    ///     Err(Error::CoroutineInactive) => {},
     ///     unexpected => panic!("unexpected result {:?}", unexpected),
     /// }
     /// # }
     /// ```
-    pub fn resume<A, R>(&self, args: A) -> LuaResult<R>
+    pub fn resume<A, R>(&self, args: A) -> Result<R>
     where
         A: ToLuaMulti<'lua>,
         R: FromLuaMulti<'lua>,
@@ -644,7 +644,7 @@ impl<'lua> LuaThread<'lua> {
 
                 let status = ffi::lua_status(thread_state);
                 if status != ffi::LUA_YIELD && ffi::lua_gettop(thread_state) == 0 {
-                    return Err(LuaError::CoroutineInactive);
+                    return Err(Error::CoroutineInactive);
                 }
 
                 ffi::lua_pop(lua.state, 1);
@@ -663,7 +663,7 @@ impl<'lua> LuaThread<'lua> {
                 )?;
 
                 let nresults = ffi::lua_gettop(thread_state);
-                let mut results = LuaMultiValue::new();
+                let mut results = MultiValue::new();
                 for _ in 0..nresults {
                     results.push_front(lua.pop_value(thread_state));
                 }
@@ -673,7 +673,7 @@ impl<'lua> LuaThread<'lua> {
     }
 
     /// Gets the status of the thread.
-    pub fn status(&self) -> LuaThreadStatus {
+    pub fn status(&self) -> ThreadStatus {
         let lua = self.0.lua;
         unsafe {
             stack_guard(lua.state, 0, || {
@@ -685,11 +685,11 @@ impl<'lua> LuaThread<'lua> {
 
                 let status = ffi::lua_status(thread_state);
                 if status != ffi::LUA_OK && status != ffi::LUA_YIELD {
-                    LuaThreadStatus::Error
+                    ThreadStatus::Error
                 } else if status == ffi::LUA_YIELD || ffi::lua_gettop(thread_state) > 0 {
-                    LuaThreadStatus::Active
+                    ThreadStatus::Active
                 } else {
-                    LuaThreadStatus::Dead
+                    ThreadStatus::Dead
                 }
             })
         }
@@ -698,7 +698,7 @@ impl<'lua> LuaThread<'lua> {
 
 /// Kinds of metamethods that can be overridden.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum LuaMetaMethod {
+pub enum MetaMethod {
     /// The `+` operator.
     Add,
     /// The `-` operator.
@@ -753,17 +753,17 @@ pub enum LuaMetaMethod {
 /// can be called as `userdata:method(args)` as expected.  If there are any regular methods, and an
 /// `Index` metamethod is given, it will be called as a *fallback* if the index doesn't match an
 /// existing regular method.
-pub struct LuaUserDataMethods<'lua, T> {
+pub struct UserDataMethods<'lua, T> {
     methods: HashMap<String, LuaCallback<'lua>>,
-    meta_methods: HashMap<LuaMetaMethod, LuaCallback<'lua>>,
+    meta_methods: HashMap<MetaMethod, LuaCallback<'lua>>,
     _type: PhantomData<T>,
 }
 
-impl<'lua, T: LuaUserDataType> LuaUserDataMethods<'lua, T> {
+impl<'lua, T: UserData> UserDataMethods<'lua, T> {
     /// Add a regular method as a function which accepts a &T as the first parameter.
     pub fn add_method<M>(&mut self, name: &str, method: M)
     where
-        M: 'lua + for<'a> FnMut(&'lua Lua, &'a T, LuaMultiValue<'lua>) -> LuaResult<LuaMultiValue<'lua>>,
+        M: 'lua + for<'a> FnMut(&'lua Lua, &'a T, MultiValue<'lua>) -> Result<MultiValue<'lua>>,
     {
         self.methods.insert(
             name.to_owned(),
@@ -773,8 +773,8 @@ impl<'lua, T: LuaUserDataType> LuaUserDataMethods<'lua, T> {
 
     /// Add a regular method as a function which accepts a &mut T as the first parameter.
     pub fn add_method_mut<M>(&mut self, name: &str, method: M)
-        where M: 'lua + for<'a> FnMut(&'lua Lua, &'a mut T, LuaMultiValue<'lua>)
-                                     -> LuaResult<LuaMultiValue<'lua>>
+        where M: 'lua + for<'a> FnMut(&'lua Lua, &'a mut T, MultiValue<'lua>)
+                                     -> Result<MultiValue<'lua>>
     {
         self.methods.insert(
             name.to_owned(),
@@ -786,7 +786,7 @@ impl<'lua, T: LuaUserDataType> LuaUserDataMethods<'lua, T> {
     /// always be a LuaUserData of type T.
     pub fn add_function<F>(&mut self, name: &str, function: F)
     where
-        F: 'lua + for<'a> FnMut(&'lua Lua, LuaMultiValue<'lua>) -> LuaResult<LuaMultiValue<'lua>>,
+        F: 'lua + for<'a> FnMut(&'lua Lua, MultiValue<'lua>) -> Result<MultiValue<'lua>>,
     {
         self.methods.insert(name.to_owned(), Box::new(function));
     }
@@ -794,9 +794,9 @@ impl<'lua, T: LuaUserDataType> LuaUserDataMethods<'lua, T> {
     /// Add a metamethod as a function which accepts a &T as the first parameter.  This can cause an
     /// error with certain binary metamethods that can trigger if ony the right side has a
     /// metatable.
-    pub fn add_meta_method<M>(&mut self, meta: LuaMetaMethod, method: M)
+    pub fn add_meta_method<M>(&mut self, meta: MetaMethod, method: M)
     where
-        M: 'lua + for<'a> FnMut(&'lua Lua, &'a T, LuaMultiValue<'lua>) -> LuaResult<LuaMultiValue<'lua>>,
+        M: 'lua + for<'a> FnMut(&'lua Lua, &'a T, MultiValue<'lua>) -> Result<MultiValue<'lua>>,
     {
         self.meta_methods.insert(meta, Self::box_method(method));
     }
@@ -804,9 +804,9 @@ impl<'lua, T: LuaUserDataType> LuaUserDataMethods<'lua, T> {
     /// Add a metamethod as a function which accepts a &mut T as the first parameter.  This can
     /// cause an error with certain binary metamethods that can trigger if ony the right side has a
     /// metatable.
-    pub fn add_meta_method_mut<M>(&mut self, meta: LuaMetaMethod, method: M)
-        where M: 'lua + for<'a> FnMut(&'lua Lua, &'a mut T, LuaMultiValue<'lua>)
-                                     -> LuaResult<LuaMultiValue<'lua>>
+    pub fn add_meta_method_mut<M>(&mut self, meta: MetaMethod, method: M)
+        where M: 'lua + for<'a> FnMut(&'lua Lua, &'a mut T, MultiValue<'lua>)
+                                     -> Result<MultiValue<'lua>>
     {
         self.meta_methods.insert(meta, Self::box_method_mut(method));
     }
@@ -815,23 +815,23 @@ impl<'lua, T: LuaUserDataType> LuaUserDataMethods<'lua, T> {
     /// binary operators can be triggered if either the left or right argument to the binary
     /// operator has a metatable, so the first argument here is not necessarily a userdata of type
     /// T.
-    pub fn add_meta_function<F>(&mut self, meta: LuaMetaMethod, function: F)
+    pub fn add_meta_function<F>(&mut self, meta: MetaMethod, function: F)
     where
-        F: 'lua + for<'a> FnMut(&'lua Lua, LuaMultiValue<'lua>) -> LuaResult<LuaMultiValue<'lua>>,
+        F: 'lua + for<'a> FnMut(&'lua Lua, MultiValue<'lua>) -> Result<MultiValue<'lua>>,
     {
         self.meta_methods.insert(meta, Box::new(function));
     }
 
     fn box_method<M>(mut method: M) -> LuaCallback<'lua>
     where
-        M: 'lua + for<'a> FnMut(&'lua Lua, &'a T, LuaMultiValue<'lua>) -> LuaResult<LuaMultiValue<'lua>>,
+        M: 'lua + for<'a> FnMut(&'lua Lua, &'a T, MultiValue<'lua>) -> Result<MultiValue<'lua>>,
     {
         Box::new(move |lua, mut args| if let Some(front) = args.pop_front() {
-            let userdata = LuaUserData::from_lua(front, lua)?;
+            let userdata = AnyUserData::from_lua(front, lua)?;
             let userdata = userdata.borrow::<T>()?;
             method(lua, &userdata, args)
         } else {
-            Err(LuaError::FromLuaConversionError(
+            Err(Error::FromLuaConversionError(
                 "No userdata supplied as first argument to method"
                     .to_owned(),
             ))
@@ -840,16 +840,16 @@ impl<'lua, T: LuaUserDataType> LuaUserDataMethods<'lua, T> {
     }
 
     fn box_method_mut<M>(mut method: M) -> LuaCallback<'lua>
-        where M: 'lua + for<'a> FnMut(&'lua Lua, &'a mut T, LuaMultiValue<'lua>)
-                                     -> LuaResult<LuaMultiValue<'lua>>
+        where M: 'lua + for<'a> FnMut(&'lua Lua, &'a mut T, MultiValue<'lua>)
+                                     -> Result<MultiValue<'lua>>
     {
         Box::new(move |lua, mut args| if let Some(front) = args.pop_front() {
-            let userdata = LuaUserData::from_lua(front, lua)?;
+            let userdata = AnyUserData::from_lua(front, lua)?;
             let mut userdata = userdata.borrow_mut::<T>()?;
             method(lua, &mut userdata, args)
         } else {
             Err(
-                LuaError::FromLuaConversionError(
+                Error::FromLuaConversionError(
                     "No userdata supplied as first argument to method".to_owned(),
                 ).into(),
             )
@@ -859,43 +859,48 @@ impl<'lua, T: LuaUserDataType> LuaUserDataMethods<'lua, T> {
 }
 
 /// Trait for custom userdata types.
-pub trait LuaUserDataType: 'static + Sized {
+pub trait UserData: 'static + Sized {
     /// Adds custom methods and operators specific to this userdata.
-    fn add_methods(_methods: &mut LuaUserDataMethods<Self>) {}
+    fn add_methods(_methods: &mut UserDataMethods<Self>) {}
 }
 
-/// Handle to an internal Lua userdata for a type that implements `LuaUserDataType`.  Internally,
-/// instances are stored in a `RefCell`, to best match the mutable semantics of the Lua language.
+/// Handle to an internal Lua userdata for any type that implements `UserData`.
+///
+/// Similar to `std::any::Any`, this provides an interface for dynamic type checking via the `is`
+/// and `borrow` methods.
+///
+/// Internally, instances are stored in a `RefCell`, to best match the mutable semantics of the Lua
+/// language.
 #[derive(Clone, Debug)]
-pub struct LuaUserData<'lua>(LuaRef<'lua>);
+pub struct AnyUserData<'lua>(LuaRef<'lua>);
 
-impl<'lua> LuaUserData<'lua> {
+impl<'lua> AnyUserData<'lua> {
     /// Checks whether `T` is the type of this userdata.
-    pub fn is<T: LuaUserDataType>(&self) -> bool {
+    pub fn is<T: UserData>(&self) -> bool {
         self.inspect(|_: &RefCell<T>| ()).is_some()
     }
 
     /// Borrow this userdata out of the internal RefCell that is held in lua.
-    pub fn borrow<T: LuaUserDataType>(&self) -> LuaResult<Ref<T>> {
+    pub fn borrow<T: UserData>(&self) -> Result<Ref<T>> {
         self.inspect(|cell| {
             Ok(
-                cell.try_borrow().map_err(|_| LuaError::UserDataBorrowError)?,
+                cell.try_borrow().map_err(|_| Error::UserDataBorrowError)?,
             )
-        }).ok_or(LuaError::UserDataTypeMismatch)?
+        }).ok_or(Error::UserDataTypeMismatch)?
     }
 
     /// Borrow mutably this userdata out of the internal RefCell that is held in lua.
-    pub fn borrow_mut<T: LuaUserDataType>(&self) -> LuaResult<RefMut<T>> {
+    pub fn borrow_mut<T: UserData>(&self) -> Result<RefMut<T>> {
         self.inspect(|cell| {
             Ok(cell.try_borrow_mut().map_err(
-                |_| LuaError::UserDataBorrowMutError,
+                |_| Error::UserDataBorrowMutError,
             )?)
-        }).ok_or(LuaError::UserDataTypeMismatch)?
+        }).ok_or(Error::UserDataTypeMismatch)?
     }
 
     fn inspect<'a, T, R, F>(&'a self, func: F) -> Option<R>
     where
-        T: LuaUserDataType,
+        T: UserData,
         F: FnOnce(&'a RefCell<T>) -> R,
     {
         unsafe {
@@ -1025,14 +1030,14 @@ impl Lua {
     /// results in better error traces.
     ///
     /// Equivalent to Lua's `load` function.
-    pub fn load(&self, source: &str, name: Option<&str>) -> LuaResult<LuaFunction> {
+    pub fn load(&self, source: &str, name: Option<&str>) -> Result<Function> {
         unsafe {
             stack_err_guard(self.state, 0, || {
                 handle_error(
                     self.state,
                     if let Some(name) = name {
                         let name = CString::new(name.to_owned()).map_err(|e| {
-                            LuaError::ToLuaConversionError(e.to_string())
+                            Error::ToLuaConversionError(e.to_string())
                         })?;
                         ffi::luaL_loadbuffer(
                             self.state,
@@ -1050,7 +1055,7 @@ impl Lua {
                     },
                 )?;
 
-                Ok(LuaFunction(self.pop_ref(self.state)))
+                Ok(Function(self.pop_ref(self.state)))
             })
         }
     }
@@ -1065,7 +1070,7 @@ impl Lua {
         &'lua self,
         source: &str,
         name: Option<&str>,
-    ) -> LuaResult<R> {
+    ) -> Result<R> {
         self.load(source, name)?.call(())
     }
 
@@ -1077,7 +1082,7 @@ impl Lua {
         &'lua self,
         source: &str,
         name: Option<&str>,
-    ) -> LuaResult<R> {
+    ) -> Result<R> {
         // First, try interpreting the lua as an expression by adding
         // "return", then as a statement.  This is the same thing the
         // actual lua repl does.
@@ -1098,18 +1103,18 @@ impl Lua {
     }
 
     /// Creates and returns a new table.
-    pub fn create_table(&self) -> LuaTable {
+    pub fn create_table(&self) -> Table {
         unsafe {
             stack_guard(self.state, 0, || {
                 check_stack(self.state, 1);
                 ffi::lua_newtable(self.state);
-                LuaTable(self.pop_ref(self.state))
+                Table(self.pop_ref(self.state))
             })
         }
     }
 
     /// Creates a table and fills it with values from an iterator.
-    pub fn create_table_from<'lua, K, V, I>(&'lua self, cont: I) -> LuaResult<LuaTable<'lua>>
+    pub fn create_table_from<'lua, K, V, I>(&'lua self, cont: I) -> Result<Table<'lua>>
     where
         K: ToLua<'lua>,
         V: ToLua<'lua>,
@@ -1125,13 +1130,13 @@ impl Lua {
                     self.push_value(self.state, v.to_lua(self)?);
                     ffi::lua_rawset(self.state, -3);
                 }
-                Ok(LuaTable(self.pop_ref(self.state)))
+                Ok(Table(self.pop_ref(self.state)))
             })
         }
     }
 
     /// Creates a table from an iterator of values, using `1..` as the keys.
-    pub fn create_sequence_from<'lua, T, I>(&'lua self, cont: I) -> LuaResult<LuaTable<'lua>>
+    pub fn create_sequence_from<'lua, T, I>(&'lua self, cont: I) -> Result<Table<'lua>>
     where
         T: ToLua<'lua>,
         I: IntoIterator<Item = T>,
@@ -1140,9 +1145,9 @@ impl Lua {
     }
 
     /// Wraps a Rust function or closure, creating a callable Lua function handle to it.
-    pub fn create_function<'lua, F>(&'lua self, func: F) -> LuaFunction<'lua>
+    pub fn create_function<'lua, F>(&'lua self, func: F) -> Function<'lua>
     where
-        F: 'lua + for<'a> FnMut(&'a Lua, LuaMultiValue<'a>) -> LuaResult<LuaMultiValue<'a>>,
+        F: 'lua + for<'a> FnMut(&'a Lua, MultiValue<'a>) -> Result<MultiValue<'a>>,
     {
         self.create_callback_function(Box::new(func))
     }
@@ -1150,7 +1155,7 @@ impl Lua {
     /// Wraps a Lua function into a new thread (or coroutine).
     ///
     /// Equivalent to `coroutine.create`.
-    pub fn create_thread<'lua>(&'lua self, func: LuaFunction<'lua>) -> LuaThread<'lua> {
+    pub fn create_thread<'lua>(&'lua self, func: Function<'lua>) -> Thread<'lua> {
         unsafe {
             stack_guard(self.state, 0, move || {
                 check_stack(self.state, 1);
@@ -1158,15 +1163,15 @@ impl Lua {
                 let thread_state = ffi::lua_newthread(self.state);
                 self.push_ref(thread_state, &func.0);
 
-                LuaThread(self.pop_ref(self.state))
+                Thread(self.pop_ref(self.state))
             })
         }
     }
 
     /// Create a Lua userdata object from a custom userdata type.
-    pub fn create_userdata<T>(&self, data: T) -> LuaUserData
+    pub fn create_userdata<T>(&self, data: T) -> AnyUserData
     where
-        T: LuaUserDataType,
+        T: UserData,
     {
         unsafe {
             stack_guard(self.state, 0, move || {
@@ -1182,18 +1187,18 @@ impl Lua {
 
                 ffi::lua_setmetatable(self.state, -2);
 
-                LuaUserData(self.pop_ref(self.state))
+                AnyUserData(self.pop_ref(self.state))
             })
         }
     }
 
     /// Returns a handle to the global environment.
-    pub fn globals(&self) -> LuaTable {
+    pub fn globals(&self) -> Table {
         unsafe {
             stack_guard(self.state, 0, move || {
                 check_stack(self.state, 1);
                 ffi::lua_rawgeti(self.state, ffi::LUA_REGISTRYINDEX, ffi::LUA_RIDX_GLOBALS);
-                LuaTable(self.pop_ref(self.state))
+                Table(self.pop_ref(self.state))
             })
         }
     }
@@ -1201,16 +1206,16 @@ impl Lua {
     /// Coerces a Lua value to a string.
     ///
     /// The value must be a string (in which case this is a no-op) or a number.
-    pub fn coerce_string<'lua>(&'lua self, v: LuaValue<'lua>) -> LuaResult<LuaString<'lua>> {
+    pub fn coerce_string<'lua>(&'lua self, v: Value<'lua>) -> Result<LuaString<'lua>> {
         match v {
-            LuaValue::String(s) => Ok(s),
+            Value::String(s) => Ok(s),
             v => unsafe {
                 stack_guard(self.state, 0, || {
                     check_stack(self.state, 1);
                     self.push_value(self.state, v);
                     if ffi::lua_tostring(self.state, -1).is_null() {
                         ffi::lua_pop(self.state, 1);
-                        Err(LuaError::FromLuaConversionError(
+                        Err(Error::FromLuaConversionError(
                             "cannot convert lua value to string".to_owned(),
                         ))
                     } else {
@@ -1225,9 +1230,9 @@ impl Lua {
     ///
     /// The value must be an integer, or a floating point number or a string that can be converted
     /// to an integer. Refer to the Lua manual for details.
-    pub fn coerce_integer(&self, v: LuaValue) -> LuaResult<LuaInteger> {
+    pub fn coerce_integer(&self, v: Value) -> Result<Integer> {
         match v {
-            LuaValue::Integer(i) => Ok(i),
+            Value::Integer(i) => Ok(i),
             v => unsafe {
                 stack_guard(self.state, 0, || {
                     check_stack(self.state, 1);
@@ -1236,7 +1241,7 @@ impl Lua {
                     let i = ffi::lua_tointegerx(self.state, -1, &mut isint);
                     ffi::lua_pop(self.state, 1);
                     if isint == 0 {
-                        Err(LuaError::FromLuaConversionError(
+                        Err(Error::FromLuaConversionError(
                             "cannot convert lua value to integer".to_owned(),
                         ))
                     } else {
@@ -1251,9 +1256,9 @@ impl Lua {
     ///
     /// The value must be a number or a string that can be converted to a number. Refer to the Lua
     /// manual for details.
-    pub fn coerce_number(&self, v: LuaValue) -> LuaResult<LuaNumber> {
+    pub fn coerce_number(&self, v: Value) -> Result<Number> {
         match v {
-            LuaValue::Number(n) => Ok(n),
+            Value::Number(n) => Ok(n),
             v => unsafe {
                 stack_guard(self.state, 0, || {
                     check_stack(self.state, 1);
@@ -1262,7 +1267,7 @@ impl Lua {
                     let n = ffi::lua_tonumberx(self.state, -1, &mut isnum);
                     ffi::lua_pop(self.state, 1);
                     if isnum == 0 {
-                        Err(LuaError::FromLuaConversionError(
+                        Err(Error::FromLuaConversionError(
                             "cannot convert lua value to number".to_owned(),
                         ))
                     } else {
@@ -1273,32 +1278,32 @@ impl Lua {
         }
     }
 
-    pub fn from<'lua, T: ToLua<'lua>>(&'lua self, t: T) -> LuaResult<LuaValue<'lua>> {
+    pub fn from<'lua, T: ToLua<'lua>>(&'lua self, t: T) -> Result<Value<'lua>> {
         t.to_lua(self)
     }
 
-    pub fn to<'lua, T: FromLua<'lua>>(&'lua self, value: LuaValue<'lua>) -> LuaResult<T> {
+    pub fn to<'lua, T: FromLua<'lua>>(&'lua self, value: Value<'lua>) -> Result<T> {
         T::from_lua(value, self)
     }
 
-    /// Packs up a value that implements `ToLuaMulti` into a `LuaMultiValue` instance.
+    /// Packs up a value that implements `ToLuaMulti` into a `MultiValue` instance.
     ///
     /// This can be used to return arbitrary Lua values from a Rust function back to Lua.
-    pub fn pack<'lua, T: ToLuaMulti<'lua>>(&'lua self, t: T) -> LuaResult<LuaMultiValue<'lua>> {
+    pub fn pack<'lua, T: ToLuaMulti<'lua>>(&'lua self, t: T) -> Result<MultiValue<'lua>> {
         t.to_lua_multi(self)
     }
 
-    /// Unpacks a `LuaMultiValue` instance into a value that implements `FromLuaMulti`.
+    /// Unpacks a `MultiValue` instance into a value that implements `FromLuaMulti`.
     ///
     /// This can be used to convert the arguments of a Rust function called by Lua.
     pub fn unpack<'lua, T: FromLuaMulti<'lua>>(
         &'lua self,
-        value: LuaMultiValue<'lua>,
-    ) -> LuaResult<T> {
+        value: MultiValue<'lua>,
+    ) -> Result<T> {
         T::from_lua_multi(value, self)
     }
 
-    fn create_callback_function<'lua>(&'lua self, func: LuaCallback<'lua>) -> LuaFunction<'lua> {
+    fn create_callback_function<'lua>(&'lua self, func: LuaCallback<'lua>) -> Function<'lua> {
         unsafe extern "C" fn callback_call_impl(state: *mut ffi::lua_State) -> c_int {
             callback_error(state, || {
                 let lua = Lua {
@@ -1310,7 +1315,7 @@ impl Lua {
                 let func = &mut *get_userdata::<LuaCallback>(state, ffi::lua_upvalueindex(1));
 
                 let nargs = ffi::lua_gettop(state);
-                let mut args = LuaMultiValue::new();
+                let mut args = MultiValue::new();
                 for _ in 0..nargs {
                     args.push_front(lua.pop_value(state));
                 }
@@ -1341,60 +1346,60 @@ impl Lua {
 
                 ffi::lua_pushcclosure(self.state, callback_call_impl, 1);
 
-                LuaFunction(self.pop_ref(self.state))
+                Function(self.pop_ref(self.state))
             })
         }
     }
 
-    unsafe fn push_value(&self, state: *mut ffi::lua_State, value: LuaValue) {
+    unsafe fn push_value(&self, state: *mut ffi::lua_State, value: Value) {
         match value {
-            LuaValue::Nil => {
+            Value::Nil => {
                 ffi::lua_pushnil(state);
             }
 
-            LuaValue::Boolean(b) => {
+            Value::Boolean(b) => {
                 ffi::lua_pushboolean(state, if b { 1 } else { 0 });
             }
 
-            LuaValue::LightUserData(ud) => {
+            Value::LightUserData(ud) => {
                 ffi::lua_pushlightuserdata(state, ud.0);
             }
 
-            LuaValue::Integer(i) => {
+            Value::Integer(i) => {
                 ffi::lua_pushinteger(state, i);
             }
 
-            LuaValue::Number(n) => {
+            Value::Number(n) => {
                 ffi::lua_pushnumber(state, n);
             }
 
-            LuaValue::String(s) => {
+            Value::String(s) => {
                 self.push_ref(state, &s.0);
             }
 
-            LuaValue::Table(t) => {
+            Value::Table(t) => {
                 self.push_ref(state, &t.0);
             }
 
-            LuaValue::Function(f) => {
+            Value::Function(f) => {
                 self.push_ref(state, &f.0);
             }
 
-            LuaValue::Thread(t) => {
+            Value::Thread(t) => {
                 self.push_ref(state, &t.0);
             }
 
-            LuaValue::UserData(ud) => {
+            Value::UserData(ud) => {
                 self.push_ref(state, &ud.0);
             }
 
-            LuaValue::Error(e) => {
+            Value::Error(e) => {
                 push_wrapped_error(state, e);
             }
         }
     }
 
-    unsafe fn pop_value(&self, state: *mut ffi::lua_State) -> LuaValue {
+    unsafe fn pop_value(&self, state: *mut ffi::lua_State) -> Value {
         match ffi::lua_type(state, -1) {
             ffi::LUA_TNIL => {
                 ffi::lua_pop(state, 1);
@@ -1402,48 +1407,48 @@ impl Lua {
             }
 
             ffi::LUA_TBOOLEAN => {
-                let b = LuaValue::Boolean(ffi::lua_toboolean(state, -1) != 0);
+                let b = Value::Boolean(ffi::lua_toboolean(state, -1) != 0);
                 ffi::lua_pop(state, 1);
                 b
             }
 
             ffi::LUA_TLIGHTUSERDATA => {
-                let ud = LuaValue::LightUserData(LuaLightUserData(ffi::lua_touserdata(state, -1)));
+                let ud = Value::LightUserData(LightUserData(ffi::lua_touserdata(state, -1)));
                 ffi::lua_pop(state, 1);
                 ud
             }
 
             ffi::LUA_TNUMBER => {
                 if ffi::lua_isinteger(state, -1) != 0 {
-                    let i = LuaValue::Integer(ffi::lua_tointeger(state, -1));
+                    let i = Value::Integer(ffi::lua_tointeger(state, -1));
                     ffi::lua_pop(state, 1);
                     i
                 } else {
-                    let n = LuaValue::Number(ffi::lua_tonumber(state, -1));
+                    let n = Value::Number(ffi::lua_tonumber(state, -1));
                     ffi::lua_pop(state, 1);
                     n
                 }
             }
 
-            ffi::LUA_TSTRING => LuaValue::String(LuaString(self.pop_ref(state))),
+            ffi::LUA_TSTRING => Value::String(LuaString(self.pop_ref(state))),
 
-            ffi::LUA_TTABLE => LuaValue::Table(LuaTable(self.pop_ref(state))),
+            ffi::LUA_TTABLE => Value::Table(Table(self.pop_ref(state))),
 
-            ffi::LUA_TFUNCTION => LuaValue::Function(LuaFunction(self.pop_ref(state))),
+            ffi::LUA_TFUNCTION => Value::Function(Function(self.pop_ref(state))),
 
             ffi::LUA_TUSERDATA => {
                 // It should not be possible to interact with userdata types
-                // other than custom LuaUserDataType types OR a WrappedError.
+                // other than custom UserData types OR a WrappedError.
                 // WrappedPanic should never be able to be caught in lua, so it
                 // should never be here.
                 if let Some(err) = pop_wrapped_error(state) {
-                    LuaValue::Error(err)
+                    Value::Error(err)
                 } else {
-                    LuaValue::UserData(LuaUserData(self.pop_ref(state)))
+                    Value::UserData(AnyUserData(self.pop_ref(state)))
                 }
             }
 
-            ffi::LUA_TTHREAD => LuaValue::Thread(LuaThread(self.pop_ref(state))),
+            ffi::LUA_TTHREAD => Value::Thread(Thread(self.pop_ref(state))),
 
             _ => unreachable!("internal error: LUA_TNONE in pop_value"),
         }
@@ -1453,7 +1458,7 @@ impl Lua {
         assert_eq!(
             lref.lua.main_state,
             self.main_state,
-            "Lua instance passed LuaValue created from a different Lua"
+            "Lua instance passed Value created from a different Lua"
         );
 
         ffi::lua_rawgeti(
@@ -1476,7 +1481,7 @@ impl Lua {
         }
     }
 
-    unsafe fn userdata_metatable<T: LuaUserDataType>(&self) -> c_int {
+    unsafe fn userdata_metatable<T: UserData>(&self) -> c_int {
         // Used if both an __index metamethod is set and regular methods, checks methods table
         // first, then __index metamethod.
         unsafe extern "C" fn meta_index_impl(state: *mut ffi::lua_State) -> c_int {
@@ -1512,7 +1517,7 @@ impl Lua {
                 HashMapEntry::Vacant(entry) => {
                     ffi::lua_newtable(self.state);
 
-                    let mut methods = LuaUserDataMethods {
+                    let mut methods = UserDataMethods {
                         methods: HashMap::new(),
                         meta_methods: HashMap::new(),
                         _type: PhantomData,
@@ -1529,7 +1534,7 @@ impl Lua {
                             push_string(self.state, &k);
                             self.push_value(
                                 self.state,
-                                LuaValue::Function(self.create_callback_function(m)),
+                                Value::Function(self.create_callback_function(m)),
                             );
                             ffi::lua_rawset(self.state, -3);
                         }
@@ -1538,46 +1543,46 @@ impl Lua {
                     }
 
                     for (k, m) in methods.meta_methods {
-                        if k == LuaMetaMethod::Index && has_methods {
+                        if k == MetaMethod::Index && has_methods {
                             push_string(self.state, "__index");
                             ffi::lua_pushvalue(self.state, -1);
                             ffi::lua_gettable(self.state, -3);
                             self.push_value(
                                 self.state,
-                                LuaValue::Function(self.create_callback_function(m)),
+                                Value::Function(self.create_callback_function(m)),
                             );
                             ffi::lua_pushcclosure(self.state, meta_index_impl, 2);
                             ffi::lua_rawset(self.state, -3);
                         } else {
                             let name = match k {
-                                LuaMetaMethod::Add => "__add",
-                                LuaMetaMethod::Sub => "__sub",
-                                LuaMetaMethod::Mul => "__mul",
-                                LuaMetaMethod::Div => "__div",
-                                LuaMetaMethod::Mod => "__mod",
-                                LuaMetaMethod::Pow => "__pow",
-                                LuaMetaMethod::Unm => "__unm",
-                                LuaMetaMethod::IDiv => "__idiv",
-                                LuaMetaMethod::BAnd => "__band",
-                                LuaMetaMethod::BOr => "__bor",
-                                LuaMetaMethod::BXor => "__bxor",
-                                LuaMetaMethod::BNot => "__bnot",
-                                LuaMetaMethod::Shl => "__shl",
-                                LuaMetaMethod::Shr => "__shr",
-                                LuaMetaMethod::Concat => "__concat",
-                                LuaMetaMethod::Len => "__len",
-                                LuaMetaMethod::Eq => "__eq",
-                                LuaMetaMethod::Lt => "__lt",
-                                LuaMetaMethod::Le => "__le",
-                                LuaMetaMethod::Index => "__index",
-                                LuaMetaMethod::NewIndex => "__newIndex",
-                                LuaMetaMethod::Call => "__call",
-                                LuaMetaMethod::ToString => "__tostring",
+                                MetaMethod::Add => "__add",
+                                MetaMethod::Sub => "__sub",
+                                MetaMethod::Mul => "__mul",
+                                MetaMethod::Div => "__div",
+                                MetaMethod::Mod => "__mod",
+                                MetaMethod::Pow => "__pow",
+                                MetaMethod::Unm => "__unm",
+                                MetaMethod::IDiv => "__idiv",
+                                MetaMethod::BAnd => "__band",
+                                MetaMethod::BOr => "__bor",
+                                MetaMethod::BXor => "__bxor",
+                                MetaMethod::BNot => "__bnot",
+                                MetaMethod::Shl => "__shl",
+                                MetaMethod::Shr => "__shr",
+                                MetaMethod::Concat => "__concat",
+                                MetaMethod::Len => "__len",
+                                MetaMethod::Eq => "__eq",
+                                MetaMethod::Lt => "__lt",
+                                MetaMethod::Le => "__le",
+                                MetaMethod::Index => "__index",
+                                MetaMethod::NewIndex => "__newIndex",
+                                MetaMethod::Call => "__call",
+                                MetaMethod::ToString => "__tostring",
                             };
                             push_string(self.state, name);
                             self.push_value(
                                 self.state,
-                                LuaValue::Function(self.create_callback_function(m)),
+                                Value::Function(self.create_callback_function(m)),
                             );
                             ffi::lua_rawset(self.state, -3);
                         }

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -784,7 +784,7 @@ impl<'lua, T: UserData> UserDataMethods<'lua, T> {
     }
 
     /// Add a regular method as a function which accepts generic arguments, the first argument will
-    /// always be a LuaUserData of type T.
+    /// always be a `UserData` of type T.
     pub fn add_function<F>(&mut self, name: &str, function: F)
     where
         F: 'lua + for<'a> FnMut(&'lua Lua, MultiValue<'lua>) -> Result<MultiValue<'lua>>,
@@ -914,7 +914,7 @@ impl<'lua> AnyUserData<'lua> {
                 lua_assert!(
                     lua.state,
                     ffi::lua_getmetatable(lua.state, -1) != 0,
-                    "LuaUserData missing metatable"
+                    "AnyUserData missing metatable"
                 );
 
                 ffi::lua_rawgeti(

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -24,7 +24,7 @@ impl<'lua, T: ToLua<'lua>, E: ToLua<'lua>> ToLuaMulti<'lua> for ::std::result::R
         match self {
             Ok(v) => result.push_back(v.to_lua(lua)?),
             Err(e) => {
-                result.push_back(LuaNil);
+                result.push_back(Nil);
                 result.push_back(e.to_lua(lua)?);
             }
         }
@@ -43,7 +43,7 @@ impl<'lua, T: ToLua<'lua>> ToLuaMulti<'lua> for T {
 
 impl<'lua, T: FromLua<'lua>> FromLuaMulti<'lua> for T {
     fn from_lua_multi(mut values: MultiValue<'lua>, lua: &'lua Lua) -> Result<Self> {
-        Ok(T::from_lua(values.pop_front().unwrap_or(LuaNil), lua)?)
+        Ok(T::from_lua(values.pop_front().unwrap_or(Nil), lua)?)
     }
 }
 
@@ -119,7 +119,7 @@ impl<'lua, H: FromLua<'lua>, A, B> FromLuaMulti<'lua> for HCons<H, HCons<A, B>>
     where HCons<A, B>: FromLuaMulti<'lua>
 {
     fn from_lua_multi(mut values: MultiValue<'lua>, lua: &'lua Lua) -> Result<Self> {
-        let val = H::from_lua(values.pop_front().unwrap_or(LuaNil), lua)?;
+        let val = H::from_lua(values.pop_front().unwrap_or(Nil), lua)?;
         let res = HCons::<A, B>::from_lua_multi(values, lua)?;
         Ok(HCons(val, res))
     }

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -1,3 +1,5 @@
+use std::result::{Result as StdResult};
+
 use hlist_macro::{HNil, HCons};
 
 use error::*;
@@ -17,7 +19,7 @@ impl<'lua> FromLuaMulti<'lua> for () {
 
 /// Result is convertible to `MultiValue` following the common lua idiom of returning the result
 /// on success, or in the case of an error, returning nil followed by the error
-impl<'lua, T: ToLua<'lua>, E: ToLua<'lua>> ToLuaMulti<'lua> for ::std::result::Result<T, E> {
+impl<'lua, T: ToLua<'lua>, E: ToLua<'lua>> ToLuaMulti<'lua> for StdResult<T, E> {
     fn to_lua_multi(self, lua: &'lua Lua) -> Result<MultiValue<'lua>> {
         let mut result = MultiValue::new();
 

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -4,22 +4,22 @@ use error::*;
 use lua::*;
 
 impl<'lua> ToLuaMulti<'lua> for () {
-    fn to_lua_multi(self, _: &'lua Lua) -> LuaResult<LuaMultiValue> {
-        Ok(LuaMultiValue::new())
+    fn to_lua_multi(self, _: &'lua Lua) -> Result<MultiValue> {
+        Ok(MultiValue::new())
     }
 }
 
 impl<'lua> FromLuaMulti<'lua> for () {
-    fn from_lua_multi(_: LuaMultiValue, _: &'lua Lua) -> LuaResult<Self> {
+    fn from_lua_multi(_: MultiValue, _: &'lua Lua) -> Result<Self> {
         Ok(())
     }
 }
 
-/// Result is convertible to `LuaMultiValue` following the common lua idiom of returning the result
+/// Result is convertible to `MultiValue` following the common lua idiom of returning the result
 /// on success, or in the case of an error, returning nil followed by the error
-impl<'lua, T: ToLua<'lua>, E: ToLua<'lua>> ToLuaMulti<'lua> for Result<T, E> {
-    fn to_lua_multi(self, lua: &'lua Lua) -> LuaResult<LuaMultiValue<'lua>> {
-        let mut result = LuaMultiValue::new();
+impl<'lua, T: ToLua<'lua>, E: ToLua<'lua>> ToLuaMulti<'lua> for ::std::result::Result<T, E> {
+    fn to_lua_multi(self, lua: &'lua Lua) -> Result<MultiValue<'lua>> {
+        let mut result = MultiValue::new();
 
         match self {
             Ok(v) => result.push_back(v.to_lua(lua)?),
@@ -34,27 +34,27 @@ impl<'lua, T: ToLua<'lua>, E: ToLua<'lua>> ToLuaMulti<'lua> for Result<T, E> {
 }
 
 impl<'lua, T: ToLua<'lua>> ToLuaMulti<'lua> for T {
-    fn to_lua_multi(self, lua: &'lua Lua) -> LuaResult<LuaMultiValue<'lua>> {
-        let mut v = LuaMultiValue::new();
+    fn to_lua_multi(self, lua: &'lua Lua) -> Result<MultiValue<'lua>> {
+        let mut v = MultiValue::new();
         v.push_back(self.to_lua(lua)?);
         Ok(v)
     }
 }
 
 impl<'lua, T: FromLua<'lua>> FromLuaMulti<'lua> for T {
-    fn from_lua_multi(mut values: LuaMultiValue<'lua>, lua: &'lua Lua) -> LuaResult<Self> {
+    fn from_lua_multi(mut values: MultiValue<'lua>, lua: &'lua Lua) -> Result<Self> {
         Ok(T::from_lua(values.pop_front().unwrap_or(LuaNil), lua)?)
     }
 }
 
-impl<'lua> ToLuaMulti<'lua> for LuaMultiValue<'lua> {
-    fn to_lua_multi(self, _: &'lua Lua) -> LuaResult<LuaMultiValue<'lua>> {
+impl<'lua> ToLuaMulti<'lua> for MultiValue<'lua> {
+    fn to_lua_multi(self, _: &'lua Lua) -> Result<MultiValue<'lua>> {
         Ok(self)
     }
 }
 
-impl<'lua> FromLuaMulti<'lua> for LuaMultiValue<'lua> {
-    fn from_lua_multi(values: LuaMultiValue<'lua>, _: &'lua Lua) -> LuaResult<Self> {
+impl<'lua> FromLuaMulti<'lua> for MultiValue<'lua> {
+    fn from_lua_multi(values: MultiValue<'lua>, _: &'lua Lua) -> Result<Self> {
         Ok(values)
     }
 }
@@ -63,44 +63,44 @@ impl<'lua> FromLuaMulti<'lua> for LuaMultiValue<'lua> {
 /// the values is all the same and the number of values is defined at runtime.  This can be included
 /// in an hlist when unpacking, but must be the final entry, and will consume the rest of the
 /// parameters given.
-pub struct LuaVariadic<T>(pub Vec<T>);
+pub struct Variadic<T>(pub Vec<T>);
 
-impl<'lua, T: ToLua<'lua>> ToLuaMulti<'lua> for LuaVariadic<T> {
-    fn to_lua_multi(self, lua: &'lua Lua) -> LuaResult<LuaMultiValue<'lua>> {
+impl<'lua, T: ToLua<'lua>> ToLuaMulti<'lua> for Variadic<T> {
+    fn to_lua_multi(self, lua: &'lua Lua) -> Result<MultiValue<'lua>> {
         self.0.into_iter().map(|e| e.to_lua(lua)).collect()
     }
 }
 
-impl<'lua, T: FromLua<'lua>> FromLuaMulti<'lua> for LuaVariadic<T> {
-    fn from_lua_multi(values: LuaMultiValue<'lua>, lua: &'lua Lua) -> LuaResult<Self> {
+impl<'lua, T: FromLua<'lua>> FromLuaMulti<'lua> for Variadic<T> {
+    fn from_lua_multi(values: MultiValue<'lua>, lua: &'lua Lua) -> Result<Self> {
         values
             .into_iter()
             .map(|e| T::from_lua(e, lua))
-            .collect::<LuaResult<Vec<T>>>()
-            .map(LuaVariadic)
+            .collect::<Result<Vec<T>>>()
+            .map(Variadic)
     }
 }
 
 impl<'lua> ToLuaMulti<'lua> for HNil {
-    fn to_lua_multi(self, _: &'lua Lua) -> LuaResult<LuaMultiValue<'lua>> {
-        Ok(LuaMultiValue::new())
+    fn to_lua_multi(self, _: &'lua Lua) -> Result<MultiValue<'lua>> {
+        Ok(MultiValue::new())
     }
 }
 
 impl<'lua> FromLuaMulti<'lua> for HNil {
-    fn from_lua_multi(_: LuaMultiValue<'lua>, _: &'lua Lua) -> LuaResult<Self> {
+    fn from_lua_multi(_: MultiValue<'lua>, _: &'lua Lua) -> Result<Self> {
         Ok(HNil)
     }
 }
 
 impl<'lua, T: ToLuaMulti<'lua>> ToLuaMulti<'lua> for HCons<T, HNil> {
-    fn to_lua_multi(self, lua: &'lua Lua) -> LuaResult<LuaMultiValue<'lua>> {
+    fn to_lua_multi(self, lua: &'lua Lua) -> Result<MultiValue<'lua>> {
         self.0.to_lua_multi(lua)
     }
 }
 
 impl<'lua, T: FromLuaMulti<'lua>> FromLuaMulti<'lua> for HCons<T, HNil> {
-    fn from_lua_multi(values: LuaMultiValue<'lua>, lua: &'lua Lua) -> LuaResult<Self> {
+    fn from_lua_multi(values: MultiValue<'lua>, lua: &'lua Lua) -> Result<Self> {
         Ok(HCons(T::from_lua_multi(values, lua)?, HNil))
     }
 }
@@ -108,7 +108,7 @@ impl<'lua, T: FromLuaMulti<'lua>> FromLuaMulti<'lua> for HCons<T, HNil> {
 impl<'lua, H: ToLua<'lua>, A, B> ToLuaMulti<'lua> for HCons<H, HCons<A, B>>
     where HCons<A, B>: ToLuaMulti<'lua>
 {
-    fn to_lua_multi(self, lua: &'lua Lua) -> LuaResult<LuaMultiValue<'lua>> {
+    fn to_lua_multi(self, lua: &'lua Lua) -> Result<MultiValue<'lua>> {
         let mut results = self.1.to_lua_multi(lua)?;
         results.push_front(self.0.to_lua(lua)?);
         Ok(results)
@@ -118,7 +118,7 @@ impl<'lua, H: ToLua<'lua>, A, B> ToLuaMulti<'lua> for HCons<H, HCons<A, B>>
 impl<'lua, H: FromLua<'lua>, A, B> FromLuaMulti<'lua> for HCons<H, HCons<A, B>>
     where HCons<A, B>: FromLuaMulti<'lua>
 {
-    fn from_lua_multi(mut values: LuaMultiValue<'lua>, lua: &'lua Lua) -> LuaResult<Self> {
+    fn from_lua_multi(mut values: MultiValue<'lua>, lua: &'lua Lua) -> Result<Self> {
         let val = H::from_lua(values.pop_front().unwrap_or(LuaNil), lua)?;
         let res = HCons::<A, B>::from_lua_multi(values, lua)?;
         Ok(HCons(val, res))

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,8 @@
+pub use {Error as LuaError, Result as LuaResult, ExternalError as LuaExternalError,
+         ExternalResult as LuaExternalResult, Value as LuaValue, Nil as LuaNil, ToLua, FromLua,
+         MultiValue as LuaMultiValue, ToLuaMulti, FromLuaMulti, Integer as LuaInteger,
+         Number as LuaNumber, LightUserData as LuaLightUserData, String as LuaString,
+         Table as LuaTable, TablePairs as LuaTablePairs, TableSequence as LuaTableSequence,
+         Function as LuaFunction, ThreadStatus as LuaThreadStatus, Thread as LuaThread,
+         MetaMethod as LuaMetaMethod, UserDataMethods as LuaUserDataMethods,
+         UserData as LuaUserData, AnyUserData as LuaAnyUserData, Lua};

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,7 +3,11 @@ use std::error;
 use std::panic::catch_unwind;
 use std::os::raw::c_void;
 
-use super::*;
+use String as LuaString;
+use {
+    Lua, Result, LuaExternalError, LightUserData, UserDataMethods, UserData, Table, Thread,
+    ThreadStatus, Error, Function, Value, Variadic, MetaMethod
+};
 
 #[test]
 fn test_set_get() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,7 +5,7 @@ use std::os::raw::c_void;
 
 use String as LuaString;
 use {
-    Lua, Result, LuaExternalError, LightUserData, UserDataMethods, UserData, Table, Thread,
+    Lua, Result, ExternalError, LightUserData, UserDataMethods, UserData, Table, Thread,
     ThreadStatus, Error, Function, Value, Variadic, MetaMethod
 };
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -809,12 +809,12 @@ fn test_num_conversion() {
 #[test]
 #[should_panic]
 fn test_expired_userdata() {
-    struct Userdata {
+    struct MyUserdata {
         id: u8,
     }
 
-    impl LuaUserDataType for Userdata {
-        fn add_methods(methods: &mut LuaUserDataMethods<Self>) {
+    impl UserData for MyUserdata {
+        fn add_methods(methods: &mut UserDataMethods<Self>) {
             methods.add_method("access", |lua, this, _| {
                 assert!(this.id == 123);
                 lua.pack(())
@@ -825,7 +825,7 @@ fn test_expired_userdata() {
     let lua = Lua::new();
     {
         let globals = lua.globals();
-        globals.set("userdata", Userdata { id: 123 }).unwrap();
+        globals.set("userdata", MyUserdata { id: 123 }).unwrap();
     }
 
     lua.eval::<()>(r#"
@@ -849,11 +849,11 @@ fn detroys_userdata() {
 
     static DROPPED: AtomicBool = ATOMIC_BOOL_INIT;
 
-    struct Userdata;
+    struct MyUserdata;
 
-    impl LuaUserDataType for Userdata {}
+    impl UserData for MyUserdata {}
 
-    impl Drop for Userdata {
+    impl Drop for MyUserdata {
         fn drop(&mut self) {
             DROPPED.store(true, Ordering::SeqCst);
         }
@@ -862,7 +862,7 @@ fn detroys_userdata() {
     let lua = Lua::new();
     {
         let globals = lua.globals();
-        globals.set("userdata", Userdata).unwrap();
+        globals.set("userdata", MyUserdata).unwrap();
     }
 
     assert_eq!(DROPPED.load(Ordering::SeqCst), false);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -381,7 +381,7 @@ fn test_scope() {
     // {
     //     let touter = globals.get::<_, Table>("touter").unwrap();
     //     touter.set("userdata", lua.create_userdata(UserData).unwrap()).unwrap();
-    //     let userdata = touter.get::<_, LuaUserData>("userdata").unwrap();
+    //     let userdata = touter.get::<_, AnyUserData>("userdata").unwrap();
     //     userdata_ref = userdata.borrow::<UserData>();
     // }
 }


### PR DESCRIPTION
cc #15

Doesn't touch `LuaString` mainly because that's a *lot* of renaming work
and the code looks weird. Also I want feedback before I proceed.