### PR TITLE
Add a test ensuring that userdata is dropped

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -833,14 +833,9 @@ fn test_expired_userdata() {
             hatch = self.userdata
         end })
 
-        print("userdata = ", userdata)
-        print("hatch = ", hatch)
-        print "collecting..."
         tbl = nil
         userdata = nil  -- make table and userdata collectable
         collectgarbage("collect")
-        print("userdata = ", userdata)
-        print("hatch = ", hatch)
         hatch:access()
     "#, None).unwrap();
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -844,3 +844,30 @@ fn test_expired_userdata() {
         hatch:access()
     "#, None).unwrap();
 }
+
+#[test]
+fn detroys_userdata() {
+    use std::sync::atomic::{Ordering, AtomicBool, ATOMIC_BOOL_INIT};
+
+    static DROPPED: AtomicBool = ATOMIC_BOOL_INIT;
+
+    struct Userdata;
+
+    impl LuaUserDataType for Userdata {}
+
+    impl Drop for Userdata {
+        fn drop(&mut self) {
+            DROPPED.store(true, Ordering::SeqCst);
+        }
+    }
+
+    let lua = Lua::new();
+    {
+        let globals = lua.globals();
+        globals.set("userdata", Userdata).unwrap();
+    }
+
+    assert_eq!(DROPPED.load(Ordering::SeqCst), false);
+    drop(lua);  // should destroy all objects
+    assert_eq!(DROPPED.load(Ordering::SeqCst), true);
+}


### PR DESCRIPTION
While reviewing 36134e6373bbdfa7ad6c787f1114c74329c902ad I noticed that this wasn't tested anywhere, which is probably bad.