### PR TITLE
Deny warnings in doc tests / doc examples

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// Deny warnings inside doc tests / examples
+#![doc(test(attr(deny(warnings))))]
+
 #[cfg_attr(test, macro_use)]
 extern crate hlist_macro;
 

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -436,6 +436,7 @@ impl<'lua> Table<'lua> {
     ///
     /// for pair in globals.pairs::<Value, Value>() {
     ///     let (key, value) = pair?;
+    /// #   let _ = (key, value);   // used
     ///     // ...
     /// }
     /// # Ok(())

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -207,7 +207,6 @@ impl<'lua> String<'lua> {
     /// # use rlua::{Lua, String};
     /// # fn main() {
     /// let lua = Lua::new();
-    /// let globals = lua.globals();
     ///
     /// let non_utf8: String = lua.eval(r#"  "test\xff"  "#, None).unwrap();
     /// assert!(non_utf8.to_str().is_err());    // oh no :(


### PR DESCRIPTION
This was needlessly annoying, but whatevs.