### PR TITLE
Relax requirements for UserData to impl FromLua

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -103,10 +103,10 @@ impl<'lua, T: UserData> ToLua<'lua> for T {
     }
 }
 
-impl<'lua, T: UserData + Copy> FromLua<'lua> for T {
+impl<'lua, T: UserData + Clone> FromLua<'lua> for T {
     fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<T> {
         match value {
-            Value::UserData(ud) => Ok(*ud.borrow::<T>()?),
+            Value::UserData(ud) => Ok(ud.borrow::<T>()?.clone()),
             _ => Err(Error::FromLuaConversionError(
                 "cannot convert lua value to userdata".to_owned(),
             )),


### PR DESCRIPTION
This was only allowed for `UserData` implementors that are also `Copy`.
This relaxes the requirement to be `Clone` instead.

While `Copy` makes sense to prevent allocations and other potentially
costly operations, other `FromLua` impls already do pretty expensive
stuff, so this seems worth it.