### PR TITLE
Major API changes before 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,3 @@ builtin-lua = ["gcc"]
 
 [build-dependencies]
 gcc = { version = "0.3", optional = true }
-
-[dependencies]
-hlist-macro = "0.1"

--- a/examples/examples.rs
+++ b/examples/examples.rs
@@ -1,5 +1,3 @@
-#[macro_use]
-extern crate hlist_macro;
 extern crate rlua;
 
 use std::f32;
@@ -82,9 +80,7 @@ fn examples() -> Result<()> {
     // This API handles variadics using Heterogeneous Lists.  This is one way to
     // call a function with multiple parameters:
 
-    print.call::<_, ()>(
-        hlist!["hello", "again", "from", "rust"],
-    )?;
+    print.call::<_, ()>(("hello", "again", "from", "rust"))?;
 
     // You can bind rust functions to lua as well
 
@@ -95,7 +91,7 @@ fn examples() -> Result<()> {
         // signature limitations, this cannot be done automatically from the
         // function signature, but this will be fixed with ATCs.  Notice the use
         // of the hlist macros again.
-        let hlist_pat![list1, list2] = lua.unpack::<HList![Vec<String>, Vec<String>]>(args)?;
+        let (list1, list2) = lua.unpack::<(Vec<String>, Vec<String>)>(args)?;
 
         // This function just checks whether two string lists are equal, and in
         // an inefficient way.  Results are returned with lua.pack, which takes
@@ -141,20 +137,20 @@ fn examples() -> Result<()> {
 
     impl UserData for Vec2 {
         fn add_methods(methods: &mut UserDataMethods<Self>) {
-            methods.add_method("magnitude", |lua, vec, _| {
+            methods.add_method("magnitude", |lua, vec, _: ()| {
                 let mag_squared = vec.0 * vec.0 + vec.1 * vec.1;
                 lua.pack(mag_squared.sqrt())
             });
 
             methods.add_meta_function(MetaMethod::Add, |lua, params| {
-                let hlist_pat![vec1, vec2] = lua.unpack::<HList![Vec2, Vec2]>(params)?;
+                let (vec1, vec2) = lua.unpack::<(Vec2, Vec2)>(params)?;
                 lua.pack(Vec2(vec1.0 + vec2.0, vec1.1 + vec2.1))
             });
         }
     }
 
     let vec2_constructor = lua.create_function(|lua, args| {
-        let hlist_pat![x, y] = lua.unpack::<HList![f32, f32]>(args)?;
+        let (x, y) = lua.unpack::<(f32, f32)>(args)?;
         lua.pack(Vec2(x, y))
     });
     globals.set("vec2", vec2_constructor)?;

--- a/examples/examples.rs
+++ b/examples/examples.rs
@@ -127,7 +127,7 @@ fn examples() -> Result<()> {
 
     impl UserData for Vec2 {
         fn add_methods(methods: &mut UserDataMethods<Self>) {
-            methods.add_method("magnitude", |_, vec, _: ()| {
+            methods.add_method("magnitude", |_, vec, ()| {
                 let mag_squared = vec.0 * vec.0 + vec.1 * vec.1;
                 Ok(mag_squared.sqrt())
             });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,6 @@
 // Deny warnings inside doc tests / examples
 #![doc(test(attr(deny(warnings))))]
 
-#[cfg_attr(test, macro_use)]
-extern crate hlist_macro;
-
 pub mod ffi;
 #[macro_use]
 mod util;

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -1506,10 +1506,9 @@ impl Lua {
     /// # fn try_main() -> Result<()> {
     /// let lua = Lua::new();
     ///
-    /// let greet = lua.create_function(|lua, args| {
-    ///     let name: String = lua.unpack(args)?;
+    /// let greet = lua.create_function(|_, name: String| {
     ///     println!("Hello, {}!", name);
-    ///     lua.pack(())
+    ///     Ok(())
     /// });
     /// # let _ = greet;    // used
     /// # Ok(())
@@ -1527,10 +1526,9 @@ impl Lua {
     /// # fn try_main() -> Result<()> {
     /// let lua = Lua::new();
     ///
-    /// let print_person = lua.create_function(|lua, args| {
-    ///     let (name, age): (String, u8) = lua.unpack(args)?;
+    /// let print_person = lua.create_function(|_, (name, age): (String, u8)| {
     ///     println!("{} is {} years old!", name, age);
-    ///     lua.pack(())
+    ///     Ok(())
     /// });
     /// # let _ = print_person;    // used
     /// # Ok(())

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -647,7 +647,6 @@ impl<'lua> Function<'lua> {
     ///
     /// ```
     /// # extern crate rlua;
-    /// # #[macro_use] extern crate hlist_macro;
     /// # use rlua::{Lua, Function, Result};
     /// # fn try_main() -> Result<()> {
     /// let lua = Lua::new();
@@ -658,7 +657,7 @@ impl<'lua> Function<'lua> {
     ///     end
     /// "#, None)?;
     ///
-    /// assert_eq!(sum.call::<_, u32>(hlist![3, 4])?, 3 + 4);
+    /// assert_eq!(sum.call::<_, u32>((3, 4))?, 3 + 4);
     ///
     /// # Ok(())
     /// # }
@@ -966,9 +965,11 @@ impl<'lua, T: UserData> UserDataMethods<'lua, T> {
     ///
     /// If `add_meta_method` is used to override the `__index` metamethod, this approach will fall
     /// back to the user-provided metamethod if no regular method was found.
-    pub fn add_method<M>(&mut self, name: &str, method: M)
+    pub fn add_method<A, R, M>(&mut self, name: &str, method: M)
     where
-        M: 'lua + for<'a> FnMut(&'lua Lua, &'a T, MultiValue<'lua>) -> Result<MultiValue<'lua>>,
+        A: 'lua + FromLuaMulti<'lua>,
+        R: 'lua + ToLuaMulti<'lua>,
+        M: 'lua + for<'a> FnMut(&'lua Lua, &'a T, A) -> Result<R>,
     {
         self.methods.insert(
             name.to_owned(),
@@ -981,9 +982,11 @@ impl<'lua, T: UserData> UserDataMethods<'lua, T> {
     /// Refer to [`add_method`] for more information about the implementation.
     ///
     /// [`add_method`]: #method.add_method
-    pub fn add_method_mut<M>(&mut self, name: &str, method: M)
+    pub fn add_method_mut<A, R, M>(&mut self, name: &str, method: M)
     where
-        M: 'lua + for<'a> FnMut(&'lua Lua, &'a mut T, MultiValue<'lua>) -> Result<MultiValue<'lua>>,
+        A: 'lua + FromLuaMulti<'lua>,
+        R: 'lua + ToLuaMulti<'lua>,
+        M: 'lua + for<'a> FnMut(&'lua Lua, &'a mut T, A) -> Result<R>,
     {
         self.methods.insert(
             name.to_owned(),
@@ -998,11 +1001,16 @@ impl<'lua, T: UserData> UserDataMethods<'lua, T> {
     ///
     /// [`add_method`]: #method.add_method
     /// [`add_method_mut`]: #method.add_method_mut
-    pub fn add_function<F>(&mut self, name: &str, function: F)
+    pub fn add_function<A, R, F>(&mut self, name: &str, function: F)
     where
-        F: 'lua + FnMut(&'lua Lua, MultiValue<'lua>) -> Result<MultiValue<'lua>>,
+        A: 'lua + FromLuaMulti<'lua>,
+        R: 'lua + ToLuaMulti<'lua>,
+        F: 'lua + FnMut(&'lua Lua, A) -> Result<R>,
     {
-        self.methods.insert(name.to_owned(), Box::new(function));
+        self.methods.insert(
+            name.to_owned(),
+            Self::box_function(function),
+        );
     }
 
     /// Add a metamethod which accepts a `&T` as the first parameter.
@@ -1013,9 +1021,11 @@ impl<'lua, T: UserData> UserDataMethods<'lua, T> {
     /// side has a metatable. To prevent this, use [`add_meta_function`].
     ///
     /// [`add_meta_function`]: #method.add_meta_function
-    pub fn add_meta_method<M>(&mut self, meta: MetaMethod, method: M)
+    pub fn add_meta_method<A, R, M>(&mut self, meta: MetaMethod, method: M)
     where
-        M: 'lua + for<'a> FnMut(&'lua Lua, &'a T, MultiValue<'lua>) -> Result<MultiValue<'lua>>,
+        A: 'lua + FromLuaMulti<'lua>,
+        R: 'lua + ToLuaMulti<'lua>,
+        M: 'lua + for<'a> FnMut(&'lua Lua, &'a T, A) -> Result<R>,
     {
         self.meta_methods.insert(meta, Self::box_method(method));
     }
@@ -1028,9 +1038,11 @@ impl<'lua, T: UserData> UserDataMethods<'lua, T> {
     /// side has a metatable. To prevent this, use [`add_meta_function`].
     ///
     /// [`add_meta_function`]: #method.add_meta_function
-    pub fn add_meta_method_mut<M>(&mut self, meta: MetaMethod, method: M)
+    pub fn add_meta_method_mut<A, R, M>(&mut self, meta: MetaMethod, method: M)
     where
-        M: 'lua + for<'a> FnMut(&'lua Lua, &'a mut T, MultiValue<'lua>) -> Result<MultiValue<'lua>>,
+        A: 'lua + FromLuaMulti<'lua>,
+        R: 'lua + ToLuaMulti<'lua>,
+        M: 'lua + for<'a> FnMut(&'lua Lua, &'a mut T, A) -> Result<R>,
     {
         self.meta_methods.insert(meta, Self::box_method_mut(method));
     }
@@ -1040,21 +1052,39 @@ impl<'lua, T: UserData> UserDataMethods<'lua, T> {
     /// Metamethods for binary operators can be triggered if either the left or right argument to
     /// the binary operator has a metatable, so the first argument here is not necessarily a
     /// userdata of type `T`.
-    pub fn add_meta_function<F>(&mut self, meta: MetaMethod, function: F)
+    pub fn add_meta_function<A, R, F>(&mut self, meta: MetaMethod, function: F)
     where
-        F: 'lua + FnMut(&'lua Lua, MultiValue<'lua>) -> Result<MultiValue<'lua>>,
+        A: 'lua + FromLuaMulti<'lua>,
+        R: 'lua + ToLuaMulti<'lua>,
+        F: 'lua + FnMut(&'lua Lua, A) -> Result<R>,
     {
-        self.meta_methods.insert(meta, Box::new(function));
+        self.meta_methods.insert(meta, Self::box_function(function));
     }
 
-    fn box_method<M>(mut method: M) -> Callback<'lua>
+    fn box_function<A, R, F>(mut function: F) -> Callback<'lua>
     where
-        M: 'lua + for<'a> FnMut(&'lua Lua, &'a T, MultiValue<'lua>) -> Result<MultiValue<'lua>>,
+        A: 'lua + FromLuaMulti<'lua>,
+        R: 'lua + ToLuaMulti<'lua>,
+        F: 'lua + for<'a> FnMut(&'lua Lua, A) -> Result<R>,
+    {
+        Box::new(move |lua, args| {
+            function(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(
+                lua,
+            )
+        })
+    }
+
+    fn box_method<A, R, M>(mut method: M) -> Callback<'lua>
+    where
+        A: 'lua + FromLuaMulti<'lua>,
+        R: 'lua + ToLuaMulti<'lua>,
+        M: 'lua + for<'a> FnMut(&'lua Lua, &'a T, A) -> Result<R>,
     {
         Box::new(move |lua, mut args| if let Some(front) = args.pop_front() {
             let userdata = AnyUserData::from_lua(front, lua)?;
             let userdata = userdata.borrow::<T>()?;
-            method(lua, &userdata, args)
+            method(lua, &userdata, A::from_lua_multi(args, lua)?)?
+                .to_lua_multi(lua)
         } else {
             Err(Error::FromLuaConversionError(
                 "No userdata supplied as first argument to method"
@@ -1063,14 +1093,17 @@ impl<'lua, T: UserData> UserDataMethods<'lua, T> {
         })
     }
 
-    fn box_method_mut<M>(mut method: M) -> Callback<'lua>
+    fn box_method_mut<A, R, M>(mut method: M) -> Callback<'lua>
     where
-        M: 'lua + for<'a> FnMut(&'lua Lua, &'a mut T, MultiValue<'lua>) -> Result<MultiValue<'lua>>,
+        A: 'lua + FromLuaMulti<'lua>,
+        R: 'lua + ToLuaMulti<'lua>,
+        M: 'lua + for<'a> FnMut(&'lua Lua, &'a mut T, A) -> Result<R>,
     {
         Box::new(move |lua, mut args| if let Some(front) = args.pop_front() {
             let userdata = AnyUserData::from_lua(front, lua)?;
             let mut userdata = userdata.borrow_mut::<T>()?;
-            method(lua, &mut userdata, args)
+            method(lua, &mut userdata, A::from_lua_multi(args, lua)?)?
+                .to_lua_multi(lua)
         } else {
             Err(
                 Error::FromLuaConversionError(
@@ -1078,7 +1111,6 @@ impl<'lua, T: UserData> UserDataMethods<'lua, T> {
                 ).into(),
             )
         })
-
     }
 }
 
@@ -1121,21 +1153,17 @@ impl<'lua, T: UserData> UserDataMethods<'lua, T> {
 ///
 /// impl UserData for MyUserData {
 ///     fn add_methods(methods: &mut UserDataMethods<Self>) {
-///         methods.add_method("get", |lua, this, args| {
-/// #           let _ = (lua, args);    // used
-///             lua.pack(this.0)
+///         methods.add_method("get", |_, this, _: ()| {
+///             Ok(this.0)
 ///         });
 ///
-///         methods.add_method_mut("add", |lua, this, args| {
-///             let value: i32 = lua.unpack(args)?;
-///
+///         methods.add_method_mut("add", |_, this, value: i32| {
 ///             this.0 += value;
-///             lua.pack(())
+///             Ok(())
 ///         });
 ///
-///         methods.add_meta_method(MetaMethod::Add, |lua, this, args| {
-///             let value: i32 = lua.unpack(args)?;
-///             lua.pack(this.0 + value)
+///         methods.add_meta_method(MetaMethod::Add, |_, this, value: i32| {
+///             Ok(this.0 + value)
 ///         });
 ///     }
 /// }
@@ -1494,14 +1522,13 @@ impl Lua {
     /// Use the `hlist_macro` crate to use multiple arguments:
     ///
     /// ```
-    /// #[macro_use] extern crate hlist_macro;
     /// # extern crate rlua;
     /// # use rlua::{Lua, Result};
     /// # fn try_main() -> Result<()> {
     /// let lua = Lua::new();
     ///
     /// let print_person = lua.create_function(|lua, args| {
-    ///     let hlist_pat![name, age]: HList![String, u8] = lua.unpack(args)?;
+    ///     let (name, age): (String, u8) = lua.unpack(args)?;
     ///     println!("{} is {} years old!", name, age);
     ///     lua.pack(())
     /// });
@@ -1512,11 +1539,15 @@ impl Lua {
     /// #     try_main().unwrap();
     /// # }
     /// ```
-    pub fn create_function<'lua, F>(&'lua self, func: F) -> Function<'lua>
+    pub fn create_function<'lua, A, R, F>(&'lua self, mut func: F) -> Function<'lua>
     where
-        F: 'lua + FnMut(&'lua Lua, MultiValue<'lua>) -> Result<MultiValue<'lua>>,
+        A: 'lua + FromLuaMulti<'lua>,
+        R: 'lua + ToLuaMulti<'lua>,
+        F: 'lua + FnMut(&'lua Lua, A) -> Result<R>,
     {
-        self.create_callback_function(Box::new(func))
+        self.create_callback_function(Box::new(move |lua, args| {
+            func(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+        }))
     }
 
     /// Wraps a Lua function into a new thread (or coroutine).

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -39,12 +39,10 @@ pub enum Value<'lua> {
     Function(Function<'lua>),
     /// Reference to a Lua thread (or coroutine).
     Thread(Thread<'lua>),
-    /// Reference to a userdata object that holds a custom type which implements
-    /// `UserData`.  Special builtin userdata types will be represented as
-    /// other `Value` variants.
+    /// Reference to a userdata object that holds a custom type which implements `UserData`.
+    /// Special builtin userdata types will be represented as other `Value` variants.
     UserData(AnyUserData<'lua>),
-    /// `Error` is a special builtin userdata type.  When received from Lua
-    /// it is implicitly cloned.
+    /// `Error` is a special builtin userdata type.  When received from Lua it is implicitly cloned.
     Error(Error),
 }
 pub use self::Value::Nil;
@@ -1518,7 +1516,7 @@ impl Lua {
     /// # }
     /// ```
     ///
-    /// Use the `hlist_macro` crate to use multiple arguments:
+    /// Use tuples to accept multiple arguments:
     ///
     /// ```
     /// # extern crate rlua;
@@ -1674,25 +1672,26 @@ impl Lua {
         }
     }
 
-    pub fn from<'lua, T: ToLua<'lua>>(&'lua self, t: T) -> Result<Value<'lua>> {
+    /// Converts a value that implements `ToLua` into a `Value` instance.
+    pub fn pack<'lua, T: ToLua<'lua>>(&'lua self, t: T) -> Result<Value<'lua>> {
         t.to_lua(self)
     }
 
-    pub fn to<'lua, T: FromLua<'lua>>(&'lua self, value: Value<'lua>) -> Result<T> {
+    /// Converts a `Value` instance into a value that implements `FromLua`.
+    pub fn unpack<'lua, T: FromLua<'lua>>(&'lua self, value: Value<'lua>) -> Result<T> {
         T::from_lua(value, self)
     }
 
-    /// Packs up a value that implements `ToLuaMulti` into a `MultiValue` instance.
-    ///
-    /// This can be used to return arbitrary Lua values from a Rust function back to Lua.
-    pub fn pack<'lua, T: ToLuaMulti<'lua>>(&'lua self, t: T) -> Result<MultiValue<'lua>> {
+    /// Converts a value that implements `ToLuaMulti` into a `MultiValue` instance.
+    pub fn pack_multi<'lua, T: ToLuaMulti<'lua>>(&'lua self, t: T) -> Result<MultiValue<'lua>> {
         t.to_lua_multi(self)
     }
 
-    /// Unpacks a `MultiValue` instance into a value that implements `FromLuaMulti`.
-    ///
-    /// This can be used to convert the arguments of a Rust function called by Lua.
-    pub fn unpack<'lua, T: FromLuaMulti<'lua>>(&'lua self, value: MultiValue<'lua>) -> Result<T> {
+    /// Converts a `MultiValue` instance into a value that implements `FromLuaMulti`.
+    pub fn unpack_multi<'lua, T: FromLuaMulti<'lua>>(
+        &'lua self,
+        value: MultiValue<'lua>,
+    ) -> Result<T> {
         T::from_lua_multi(value, self)
     }
 

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -1,21 +1,7 @@
 use std::result::Result as StdResult;
 
-use hlist_macro::{HNil, HCons};
-
 use error::*;
 use lua::*;
-
-impl<'lua> ToLuaMulti<'lua> for () {
-    fn to_lua_multi(self, _: &'lua Lua) -> Result<MultiValue> {
-        Ok(MultiValue::new())
-    }
-}
-
-impl<'lua> FromLuaMulti<'lua> for () {
-    fn from_lua_multi(_: MultiValue, _: &'lua Lua) -> Result<Self> {
-        Ok(())
-    }
-}
 
 /// Result is convertible to `MultiValue` following the common lua idiom of returning the result
 /// on success, or in the case of an error, returning nil followed by the error
@@ -83,48 +69,79 @@ impl<'lua, T: FromLua<'lua>> FromLuaMulti<'lua> for Variadic<T> {
     }
 }
 
-impl<'lua> ToLuaMulti<'lua> for HNil {
-    fn to_lua_multi(self, _: &'lua Lua) -> Result<MultiValue<'lua>> {
-        Ok(MultiValue::new())
-    }
+macro_rules! impl_tuple {
+    () => (
+        impl<'lua> ToLuaMulti<'lua> for () {
+            fn to_lua_multi(self, _: &'lua Lua) -> Result<MultiValue> {
+                Ok(MultiValue::new())
+            }
+        }
+
+        impl<'lua> FromLuaMulti<'lua> for () {
+            fn from_lua_multi(_: MultiValue, _: &'lua Lua) -> Result<Self> {
+                Ok(())
+            }
+        }
+    );
+
+    ($last:ident $($name:ident)*) => (
+        impl<'lua, $($name,)* $last> ToLuaMulti<'lua> for ($($name,)* $last,)
+            where $($name: ToLua<'lua>,)*
+                  $last: ToLuaMulti<'lua>
+        {
+            #[allow(unused_mut)]
+            #[allow(non_snake_case)]
+            fn to_lua_multi(self, lua: &'lua Lua) -> Result<MultiValue<'lua>> {
+                let ($($name,)* $last,) = self;
+
+                let mut results = $last.to_lua_multi(lua)?;
+                push_reverse!(results, $($name.to_lua(lua)?,)*);
+                Ok(results)
+            }
+        }
+
+        impl<'lua, $($name,)* $last> FromLuaMulti<'lua> for ($($name,)* $last,)
+            where $($name: FromLua<'lua>,)*
+                  $last: FromLuaMulti<'lua>
+        {
+            #[allow(unused_mut)]
+            #[allow(non_snake_case)]
+            fn from_lua_multi(mut values: MultiValue<'lua>, lua: &'lua Lua) -> Result<Self> {
+                $(let $name = values.pop_front().unwrap_or(Nil);)*
+                let $last = FromLuaMulti::from_lua_multi(values, lua)?;
+                Ok(($(FromLua::from_lua($name, lua)?,)* $last,))
+            }
+        }
+    );
 }
 
-impl<'lua> FromLuaMulti<'lua> for HNil {
-    fn from_lua_multi(_: MultiValue<'lua>, _: &'lua Lua) -> Result<Self> {
-        Ok(HNil)
-    }
+macro_rules! push_reverse {
+    ($multi_value:expr, $first:expr, $($rest:expr,)*) => (
+        push_reverse!($multi_value, $($rest,)*);
+        $multi_value.push_front($first);
+    );
+
+    ($multi_value:expr, $first:expr) => (
+        $multi_value.push_front($first);
+    );
+
+    ($multi_value:expr,) => ();
 }
 
-impl<'lua, T: ToLuaMulti<'lua>> ToLuaMulti<'lua> for HCons<T, HNil> {
-    fn to_lua_multi(self, lua: &'lua Lua) -> Result<MultiValue<'lua>> {
-        self.0.to_lua_multi(lua)
-    }
-}
-
-impl<'lua, T: FromLuaMulti<'lua>> FromLuaMulti<'lua> for HCons<T, HNil> {
-    fn from_lua_multi(values: MultiValue<'lua>, lua: &'lua Lua) -> Result<Self> {
-        Ok(HCons(T::from_lua_multi(values, lua)?, HNil))
-    }
-}
-
-impl<'lua, H: ToLua<'lua>, A, B> ToLuaMulti<'lua> for HCons<H, HCons<A, B>>
-where
-    HCons<A, B>: ToLuaMulti<'lua>,
-{
-    fn to_lua_multi(self, lua: &'lua Lua) -> Result<MultiValue<'lua>> {
-        let mut results = self.1.to_lua_multi(lua)?;
-        results.push_front(self.0.to_lua(lua)?);
-        Ok(results)
-    }
-}
-
-impl<'lua, H: FromLua<'lua>, A, B> FromLuaMulti<'lua> for HCons<H, HCons<A, B>>
-where
-    HCons<A, B>: FromLuaMulti<'lua>,
-{
-    fn from_lua_multi(mut values: MultiValue<'lua>, lua: &'lua Lua) -> Result<Self> {
-        let val = H::from_lua(values.pop_front().unwrap_or(Nil), lua)?;
-        let res = HCons::<A, B>::from_lua_multi(values, lua)?;
-        Ok(HCons(val, res))
-    }
-}
+impl_tuple! { }
+impl_tuple! { A }
+impl_tuple! { A B }
+impl_tuple! { A B C }
+impl_tuple! { A B C D }
+impl_tuple! { A B C D E }
+impl_tuple! { A B C D E F }
+impl_tuple! { A B C D E F G }
+impl_tuple! { A B C D E F G H }
+impl_tuple! { A B C D E F G H I }
+impl_tuple! { A B C D E F G H I J }
+impl_tuple! { A B C D E F G H I J K }
+impl_tuple! { A B C D E F G H I J K L }
+impl_tuple! { A B C D E F G H I J K L M }
+impl_tuple! { A B C D E F G H I J K L M N }
+impl_tuple! { A B C D E F G H I J K L M N O }
+impl_tuple! { A B C D E F G H I J K L M N O P }

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -167,19 +167,15 @@ macro_rules! push_reverse {
 }
 
 impl_tuple!{}
-impl_tuple! { A }
-impl_tuple! { A B }
-impl_tuple! { A B C }
-impl_tuple! { A B C D }
-impl_tuple! { A B C D E }
-impl_tuple! { A B C D E F }
-impl_tuple! { A B C D E F G }
-impl_tuple! { A B C D E F G H }
-impl_tuple! { A B C D E F G H I }
-impl_tuple! { A B C D E F G H I J }
-impl_tuple! { A B C D E F G H I J K }
-impl_tuple! { A B C D E F G H I J K L }
-impl_tuple! { A B C D E F G H I J K L M }
-impl_tuple! { A B C D E F G H I J K L M N }
-impl_tuple! { A B C D E F G H I J K L M N O }
-impl_tuple! { A B C D E F G H I J K L M N O P }
+impl_tuple!{A}
+impl_tuple!{A B}
+impl_tuple!{A B C}
+impl_tuple!{A B C D}
+impl_tuple!{A B C D E}
+impl_tuple!{A B C D E F}
+impl_tuple!{A B C D E F G}
+impl_tuple!{A B C D E F G H}
+impl_tuple!{A B C D E F G H I}
+impl_tuple!{A B C D E F G H I J}
+impl_tuple!{A B C D E F G H I J K}
+impl_tuple!{A B C D E F G H I J K L}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -220,7 +220,7 @@ fn test_rust_function() {
     ).unwrap();
 
     let lua_function = globals.get::<_, Function>("lua_function").unwrap();
-    let rust_function = lua.create_function(|_, _: ()| Ok("hello"));
+    let rust_function = lua.create_function(|_, ()| Ok("hello"));
 
     globals.set("rust_function", rust_function).unwrap();
     assert_eq!(lua_function.call::<_, String>(()).unwrap(), "hello");
@@ -254,7 +254,7 @@ fn test_methods() {
 
     impl UserData for MyUserData {
         fn add_methods(methods: &mut UserDataMethods<Self>) {
-            methods.add_method("get_value", |_, data, _: ()| Ok(data.0));
+            methods.add_method("get_value", |_, data, ()| Ok(data.0));
             methods.add_method_mut("set_value", |_, data, args| {
                 data.0 = args;
                 Ok(())
@@ -294,7 +294,7 @@ fn test_metamethods() {
 
     impl UserData for MyUserData {
         fn add_methods(methods: &mut UserDataMethods<Self>) {
-            methods.add_method("get", |_, data, _: ()| Ok(data.0));
+            methods.add_method("get", |_, data, ()| Ok(data.0));
             methods.add_meta_function(MetaMethod::Add, |_, (lhs, rhs): (MyUserData, MyUserData)| {
                 Ok(MyUserData(lhs.0 + rhs.0))
             });
@@ -481,7 +481,7 @@ fn test_error() {
     ).unwrap();
 
     let rust_error_function =
-        lua.create_function(|_, _: ()| -> Result<()> { Err(TestError.to_lua_err()) });
+        lua.create_function(|_, ()| -> Result<()> { Err(TestError.to_lua_err()) });
     globals
         .set("rust_error_function", rust_error_function)
         .unwrap();
@@ -540,7 +540,7 @@ fn test_error() {
             "#,
             None,
         )?;
-        let rust_panic_function = lua.create_function(|_, _: ()| -> Result<()> {
+        let rust_panic_function = lua.create_function(|_, ()| -> Result<()> {
             panic!("expected panic, this panic should be caught in rust")
         });
         globals.set("rust_panic_function", rust_panic_function)?;
@@ -566,7 +566,7 @@ fn test_error() {
             "#,
             None,
         )?;
-        let rust_panic_function = lua.create_function(|_, _: ()| -> Result<()> {
+        let rust_panic_function = lua.create_function(|_, ()| -> Result<()> {
             panic!("expected panic, this panic should be caught in rust")
         });
         globals.set("rust_panic_function", rust_panic_function)?;
@@ -723,12 +723,12 @@ fn test_result_conversions() {
     let lua = Lua::new();
     let globals = lua.globals();
 
-    let err = lua.create_function(|_, _: ()| {
+    let err = lua.create_function(|_, ()| {
         Ok(Err::<String, _>(
             "only through failure can we succeed".to_lua_err(),
         ))
     });
-    let ok = lua.create_function(|_, _: ()| Ok(Ok::<_, Error>("!".to_owned())));
+    let ok = lua.create_function(|_, ()| Ok(Ok::<_, Error>("!".to_owned())));
 
     globals.set("err", err).unwrap();
     globals.set("ok", ok).unwrap();
@@ -780,7 +780,7 @@ fn test_expired_userdata() {
 
     impl UserData for MyUserdata {
         fn add_methods(methods: &mut UserDataMethods<Self>) {
-            methods.add_method("access", |_, this, _: ()| {
+            methods.add_method("access", |_, this, ()| {
                 assert!(this.id == 123);
                 Ok(())
             });
@@ -869,7 +869,7 @@ fn string_views() {
 #[test]
 fn coroutine_from_closure() {
     let lua = Lua::new();
-    let thrd_main = lua.create_function(|_, _: ()| Ok(()));
+    let thrd_main = lua.create_function(|_, ()| Ok(()));
     lua.globals().set("main", thrd_main).unwrap();
     let thrd: Thread = lua.eval("coroutine.create(main)", None).unwrap();
     thrd.resume::<_, ()>(()).unwrap();
@@ -879,7 +879,7 @@ fn coroutine_from_closure() {
 #[should_panic]
 fn coroutine_panic() {
     let lua = Lua::new();
-    let thrd_main = lua.create_function(|lua, _: ()| {
+    let thrd_main = lua.create_function(|lua, ()| {
         // whoops, 'main' has a wrong type
         let _coro: u32 = lua.globals().get("main").unwrap();
         Ok(())

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -220,9 +220,7 @@ fn test_rust_function() {
     ).unwrap();
 
     let lua_function = globals.get::<_, Function>("lua_function").unwrap();
-    let rust_function = lua.create_function(|_, _: ()| {
-        Ok("hello")
-    });
+    let rust_function = lua.create_function(|_, _: ()| Ok("hello"));
 
     globals.set("rust_function", rust_function).unwrap();
     assert_eq!(lua_function.call::<_, String>(()).unwrap(), "hello");
@@ -303,13 +301,14 @@ fn test_metamethods() {
             methods.add_meta_function(MetaMethod::Sub, |_, (lhs, rhs): (MyUserData, MyUserData)| {
                 Ok(MyUserData(lhs.0 - rhs.0))
             });
-            methods.add_meta_method(MetaMethod::Index, |_, data, index: LuaString| {
-                if index.to_str()? == "inner" {
+            methods.add_meta_method(
+                MetaMethod::Index,
+                |_, data, index: LuaString| if index.to_str()? == "inner" {
                     Ok(data.0)
                 } else {
                     Err("no such custom index".to_lua_err())
-                }
-            });
+                },
+            );
         }
     }
 
@@ -382,9 +381,9 @@ fn test_lua_multi() {
     assert_eq!(concat.call::<_, String>(("foo", "bar")).unwrap(), "foobar");
     let (a, b) = mreturn.call::<_, (u64, u64)>(()).unwrap();
     assert_eq!((a, b), (1, 2));
-    let (a, b, Variadic(v)) = mreturn.call::<_, (u64, u64, Variadic<u64>)>(()).unwrap();
+    let (a, b, v) = mreturn.call::<_, (u64, u64, Variadic<u64>)>(()).unwrap();
     assert_eq!((a, b), (1, 2));
-    assert_eq!(v, vec![3, 4, 5, 6]);
+    assert_eq!(v[..], [3, 4, 5, 6]);
 }
 
 #[test]


### PR DESCRIPTION
First of all, I do NOT intend to merge this pull request as is, it was done very quickly and without updating documentation, this is only for the purposes of discussion.

This PR contains two major API changes, and I want to discuss whether one or both of these should be merged in before 0.9.  First, HLists are no more, and are instead replaced entirely with tuples.  Second, the argument and return types of callbacks are now generic, and the packing / unpacking is done automatically as the callback is called.

I'm not sure whether EITHER of these changes makes for a nicer API, really.  They make it possible *some of the time* to have to type less lines, but I'm not sure either really make things more readable or understandable.

I feel like there's a nicer API hiding in here somewhere though, and I'd like to brainstorm about ways I could change this to be nicer and fix some of the problems.

Things about this API change that I don't like:

Underscore soup and `_: ()`
```lua.create_function(|_, _: ()| <whatever>)```

The fact that everything is now tuples more sharply highlights some of the limitations and silliness 
```let v: f32 = func.call(())?;```
```func.call::<_, ()>((a, b))?;```

Anyway, maybe my concerns are overblown, and this API is a strict improvement?