### PR TITLE
[WIP] Enhanced errors

### DIFF
--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -32,7 +32,7 @@ fn main() {
                     );
                     break;
                 }
-                Err(Error::IncompleteStatement(_)) => {
+                Err(Error::SyntaxError { incomplete_input: true, .. }) => {
                     // continue reading input and append it to `line`
                     write!(stdout, ">> ").unwrap();
                     stdout.flush().unwrap();

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -39,9 +39,12 @@ impl<'lua> FromLua<'lua> for Table<'lua> {
     fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<Table<'lua>> {
         match value {
             Value::Table(table) => Ok(table),
-            _ => Err(Error::FromLuaConversionError(
-                "cannot convert lua value to table".to_owned(),
-            )),
+            _ => Err(Error::FromLuaConversionError {
+                from: value.type_name(),
+                to: "table",
+                expected: None,
+                message: None,
+            }),
         }
     }
 }
@@ -56,9 +59,12 @@ impl<'lua> FromLua<'lua> for Function<'lua> {
     fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<Function<'lua>> {
         match value {
             Value::Function(table) => Ok(table),
-            _ => Err(Error::FromLuaConversionError(
-                "cannot convert lua value to function".to_owned(),
-            )),
+            _ => Err(Error::FromLuaConversionError {
+                from: value.type_name(),
+                to: "function",
+                expected: None,
+                message: None,
+            }),
         }
     }
 }
@@ -73,9 +79,12 @@ impl<'lua> FromLua<'lua> for Thread<'lua> {
     fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<Thread<'lua>> {
         match value {
             Value::Thread(t) => Ok(t),
-            _ => Err(Error::FromLuaConversionError(
-                "cannot convert lua value to thread".to_owned(),
-            )),
+            _ => Err(Error::FromLuaConversionError {
+                from: value.type_name(),
+                to: "thread",
+                expected: None,
+                message: None,
+            }),
         }
     }
 }
@@ -90,9 +99,12 @@ impl<'lua> FromLua<'lua> for AnyUserData<'lua> {
     fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<AnyUserData<'lua>> {
         match value {
             Value::UserData(ud) => Ok(ud),
-            _ => Err(Error::FromLuaConversionError(
-                "cannot convert lua value to userdata".to_owned(),
-            )),
+            _ => Err(Error::FromLuaConversionError {
+                from: value.type_name(),
+                to: "userdata",
+                expected: None,
+                message: None,
+            }),
         }
     }
 }
@@ -107,9 +119,12 @@ impl<'lua, T: UserData + Clone> FromLua<'lua> for T {
     fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<T> {
         match value {
             Value::UserData(ud) => Ok(ud.borrow::<T>()?.clone()),
-            _ => Err(Error::FromLuaConversionError(
-                "cannot convert lua value to userdata".to_owned(),
-            )),
+            _ => Err(Error::FromLuaConversionError {
+                from: value.type_name(),
+                to: "userdata",
+                expected: None,
+                message: None,
+            }),
         }
     }
 }
@@ -156,12 +171,15 @@ impl<'lua> ToLua<'lua> for LightUserData {
 }
 
 impl<'lua> FromLua<'lua> for LightUserData {
-    fn from_lua(v: Value, _: &'lua Lua) -> Result<Self> {
-        match v {
+    fn from_lua(value: Value, _: &'lua Lua) -> Result<Self> {
+        match value {
             Value::LightUserData(ud) => Ok(ud),
-            _ => Err(Error::FromLuaConversionError(
-                "cannot convert lua value to lightuserdata".to_owned(),
-            )),
+            _ => Err(Error::FromLuaConversionError {
+                from: value.type_name(),
+                to: "light userdata",
+                expected: None,
+                message: None,
+            }),
         }
     }
 }
@@ -241,9 +259,12 @@ impl<'lua, T: FromLua<'lua>> FromLua<'lua> for Vec<T> {
         if let Value::Table(table) = value {
             table.sequence_values().collect()
         } else {
-            Err(Error::FromLuaConversionError(
-                "cannot convert lua value to table for Vec".to_owned(),
-            ))
+            Err(Error::FromLuaConversionError {
+                from: value.type_name(),
+                to: "Vec",
+                expected: Some("table"),
+                message: None,
+            })
         }
     }
 }
@@ -259,9 +280,12 @@ impl<'lua, K: Eq + Hash + FromLua<'lua>, V: FromLua<'lua>> FromLua<'lua> for Has
         if let Value::Table(table) = value {
             table.pairs().collect()
         } else {
-            Err(Error::FromLuaConversionError(
-                "cannot convert lua value to table for HashMap".to_owned(),
-            ))
+            Err(Error::FromLuaConversionError {
+                from: value.type_name(),
+                to: "HashMap",
+                expected: Some("table"),
+                message: None,
+            })
         }
     }
 }
@@ -277,9 +301,12 @@ impl<'lua, K: Ord + FromLua<'lua>, V: FromLua<'lua>> FromLua<'lua> for BTreeMap<
         if let Value::Table(table) = value {
             table.pairs().collect()
         } else {
-            Err(Error::FromLuaConversionError(
-                "cannot convert lua value to table for BTreeMap".to_owned(),
-            ))
+            Err(Error::FromLuaConversionError {
+                from: value.type_name(),
+                to: "BTreeMap",
+                expected: Some("table"),
+                message: None,
+            })
         }
     }
 }

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -42,7 +42,6 @@ impl<'lua> FromLua<'lua> for Table<'lua> {
             _ => Err(Error::FromLuaConversionError {
                 from: value.type_name(),
                 to: "table",
-                expected: None,
                 message: None,
             }),
         }
@@ -62,7 +61,6 @@ impl<'lua> FromLua<'lua> for Function<'lua> {
             _ => Err(Error::FromLuaConversionError {
                 from: value.type_name(),
                 to: "function",
-                expected: None,
                 message: None,
             }),
         }
@@ -82,7 +80,6 @@ impl<'lua> FromLua<'lua> for Thread<'lua> {
             _ => Err(Error::FromLuaConversionError {
                 from: value.type_name(),
                 to: "thread",
-                expected: None,
                 message: None,
             }),
         }
@@ -102,7 +99,6 @@ impl<'lua> FromLua<'lua> for AnyUserData<'lua> {
             _ => Err(Error::FromLuaConversionError {
                 from: value.type_name(),
                 to: "userdata",
-                expected: None,
                 message: None,
             }),
         }
@@ -122,7 +118,6 @@ impl<'lua, T: UserData + Clone> FromLua<'lua> for T {
             _ => Err(Error::FromLuaConversionError {
                 from: value.type_name(),
                 to: "userdata",
-                expected: None,
                 message: None,
             }),
         }
@@ -177,7 +172,6 @@ impl<'lua> FromLua<'lua> for LightUserData {
             _ => Err(Error::FromLuaConversionError {
                 from: value.type_name(),
                 to: "light userdata",
-                expected: None,
                 message: None,
             }),
         }
@@ -262,8 +256,7 @@ impl<'lua, T: FromLua<'lua>> FromLua<'lua> for Vec<T> {
             Err(Error::FromLuaConversionError {
                 from: value.type_name(),
                 to: "Vec",
-                expected: Some("table"),
-                message: None,
+                message: Some("expected table".to_string()),
             })
         }
     }
@@ -283,8 +276,7 @@ impl<'lua, K: Eq + Hash + FromLua<'lua>, V: FromLua<'lua>> FromLua<'lua> for Has
             Err(Error::FromLuaConversionError {
                 from: value.type_name(),
                 to: "HashMap",
-                expected: Some("table"),
-                message: None,
+                message: Some("expected table".to_string()),
             })
         }
     }
@@ -304,8 +296,7 @@ impl<'lua, K: Ord + FromLua<'lua>, V: FromLua<'lua>> FromLua<'lua> for BTreeMap<
             Err(Error::FromLuaConversionError {
                 from: value.type_name(),
                 to: "BTreeMap",
-                expected: Some("table"),
-                message: None,
+                message: Some("expected table".to_string()),
             })
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -112,8 +112,8 @@ impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::SyntaxError { ref message, .. } => write!(fmt, "syntax error: {}", message),
-            Error::RuntimeError(ref msg) => write!(fmt, "Lua runtime error: {}", msg),
-            Error::ErrorError(ref msg) => write!(fmt, "Lua error in error handler: {}", msg),
+            Error::RuntimeError(ref msg) => write!(fmt, "runtime error: {}", msg),
+            Error::ErrorError(ref msg) => write!(fmt, "error in error handler: {}", msg),
             Error::ToLuaConversionError { from, to, ref message } => {
                 write!(fmt, "error converting {} to Lua {}", from, to)?;
                 match *message {
@@ -131,10 +131,10 @@ impl fmt::Display for Error {
                         write!(fmt, " ({}; expected {})", message, expected),
                 }
             }
-            Error::CoroutineInactive => write!(fmt, "Cannot resume inactive coroutine"),
-            Error::UserDataTypeMismatch => write!(fmt, "Userdata not expected type"),
-            Error::UserDataBorrowError => write!(fmt, "Userdata already mutably borrowed"),
-            Error::UserDataBorrowMutError => write!(fmt, "Userdata already borrowed"),
+            Error::CoroutineInactive => write!(fmt, "cannot resume inactive coroutine"),
+            Error::UserDataTypeMismatch => write!(fmt, "userdata is not expected type"),
+            Error::UserDataBorrowError => write!(fmt, "userdata already mutably borrowed"),
+            Error::UserDataBorrowMutError => write!(fmt, "userdata already borrowed"),
             Error::CallbackError { ref cause, .. } => write!(fmt, "{}", cause),
             Error::ExternalError(ref err) => err.fmt(fmt),
         }
@@ -145,14 +145,14 @@ impl StdError for Error {
     fn description(&self) -> &str {
         match *self {
             Error::SyntaxError { .. } => "syntax error",
-            Error::RuntimeError(_) => "lua runtime error",
-            Error::ErrorError(_) => "lua error handling error",
+            Error::RuntimeError(_) => "runtime error",
+            Error::ErrorError(_) => "error inside error handler",
             Error::ToLuaConversionError { .. } => "conversion error to lua",
             Error::FromLuaConversionError { .. } => "conversion error from lua",
-            Error::CoroutineInactive => "lua coroutine inactive",
-            Error::UserDataTypeMismatch => "lua userdata type mismatch",
-            Error::UserDataBorrowError => "lua userdata already mutably borrowed",
-            Error::UserDataBorrowMutError => "lua userdata already borrowed",
+            Error::CoroutineInactive => "attempt to resume inactive coroutine",
+            Error::UserDataTypeMismatch => "userdata type mismatch",
+            Error::UserDataBorrowError => "userdata already mutably borrowed",
+            Error::UserDataBorrowMutError => "userdata already borrowed",
             Error::CallbackError { ref cause, .. } => cause.description(),
             Error::ExternalError(ref err) => err.description(),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,11 +22,6 @@ pub enum Error {
     /// Among other things, this includes invoking operators on wrong types (such as calling or
     /// indexing a `nil` value).
     RuntimeError(String),
-    /// Lua error from inside an error handler, aka `LUA_ERRERR`.
-    ///
-    /// To prevent an infinite recursion when invoking an error handler, this error will be returned
-    /// instead of invoking the error handler.
-    ErrorError(String),
     /// A Rust value could not be converted to a Lua value.
     ToLuaConversionError {
         /// Name of the Rust type that could not be converted.
@@ -108,7 +103,6 @@ impl fmt::Display for Error {
         match *self {
             Error::SyntaxError { ref message, .. } => write!(fmt, "syntax error: {}", message),
             Error::RuntimeError(ref msg) => write!(fmt, "runtime error: {}", msg),
-            Error::ErrorError(ref msg) => write!(fmt, "error in error handler: {}", msg),
             Error::ToLuaConversionError { from, to, ref message } => {
                 write!(fmt, "error converting {} to Lua {}", from, to)?;
                 match *message {
@@ -138,7 +132,6 @@ impl StdError for Error {
         match *self {
             Error::SyntaxError { .. } => "syntax error",
             Error::RuntimeError(_) => "runtime error",
-            Error::ErrorError(_) => "error inside error handler",
             Error::ToLuaConversionError { .. } => "conversion error to lua",
             Error::FromLuaConversionError { .. } => "conversion error from lua",
             Error::CoroutineInactive => "attempt to resume inactive coroutine",

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,11 +42,6 @@ pub enum Error {
         from: &'static str,
         /// Name of the Rust type that could not be created.
         to: &'static str,
-        /// A string indicating the possible Lua values/types for this conversion.
-        ///
-        /// To avoid redundancy, this should only be set to `Some` when there are nontrivial rules
-        /// about valid conversions, since the `to` string should already hint at the problem.
-        expected: Option<&'static str>,
         /// A string containing more detailed error information.
         message: Option<String>,
     },
@@ -121,14 +116,11 @@ impl fmt::Display for Error {
                     Some(ref message) => write!(fmt, " ({})", message),
                 }
             }
-            Error::FromLuaConversionError { from, to, ref expected, ref message } => {
+            Error::FromLuaConversionError { from, to, ref message } => {
                 write!(fmt, "error converting Lua {} to {}", from, to)?;
-                match (expected.as_ref(), message.as_ref()) {
-                    (None, None) => Ok(()),
-                    (None, Some(ref message)) => write!(fmt, " ({})", message),
-                    (Some(ref expected), None) => write!(fmt, " (expected {})", expected),
-                    (Some(ref expected), Some(ref message)) =>
-                        write!(fmt, " ({}; expected {})", message, expected),
+                match *message {
+                    None => Ok(()),
+                    Some(ref message) => write!(fmt, " ({})", message),
                 }
             }
             Error::CoroutineInactive => write!(fmt, "cannot resume inactive coroutine"),

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -211,7 +211,6 @@ impl<'lua> String<'lua> {
         str::from_utf8(self.as_bytes()).map_err(|e| Error::FromLuaConversionError {
             from: "string",
             to: "&str",
-            expected: Some("utf-8 string"),
             message: Some(e.to_string()),
         })
     }
@@ -1109,8 +1108,7 @@ impl<'lua, T: UserData> UserDataMethods<'lua, T> {
         } else {
             Err(Error::FromLuaConversionError {
                 from: "missing argument",
-                to: "UserData",
-                expected: Some("userdata"),
+                to: "userdata",
                 message: None,
             })
         })
@@ -1130,8 +1128,7 @@ impl<'lua, T: UserData> UserDataMethods<'lua, T> {
         } else {
             Err(Error::FromLuaConversionError {
                 from: "missing argument",
-                to: "UserData",
-                expected: Some("userdata"),
+                to: "userdata",
                 message: None,
             })
         })
@@ -1643,8 +1640,7 @@ impl Lua {
                         Err(Error::FromLuaConversionError {
                             from: ty,
                             to: "String",
-                            expected: Some("string or number"),
-                            message: None,
+                            message: Some("expected string or number".to_string()),
                         })
                     } else {
                         Ok(String(self.pop_ref(self.state)))
@@ -1673,7 +1669,6 @@ impl Lua {
                         Err(Error::FromLuaConversionError {
                             from: ty,
                             to: "integer",
-                            expected: None,
                             message: None,
                         })
                     } else {
@@ -1703,8 +1698,7 @@ impl Lua {
                         Err(Error::FromLuaConversionError {
                             from: ty,
                             to: "number",
-                            expected: Some("number or string coercible to number"),
-                            message: None,
+                            message: Some("number or string coercible to number".to_string()),
                         })
                     } else {
                         Ok(n)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -69,8 +69,8 @@ fn test_eval() {
     assert_eq!(lua.eval::<bool>("false == false", None).unwrap(), true);
     assert_eq!(lua.eval::<i32>("return 1 + 2", None).unwrap(), 3);
     match lua.eval::<()>("if true then", None) {
-        Err(Error::IncompleteStatement(_)) => {}
-        r => panic!("expected IncompleteStatement, got {:?}", r),
+        Err(Error::SyntaxError { incomplete_input: true, .. }) => {}
+        r => panic!("expected SyntaxError with incomplete_input=true, got {:?}", r),
     }
 }
 
@@ -514,12 +514,12 @@ fn test_error() {
     assert!(return_string_error.call::<_, Error>(()).is_ok());
 
     match lua.eval::<()>("if youre happy and you know it syntax error", None) {
-        Err(Error::SyntaxError(_)) => {}
+        Err(Error::SyntaxError { incomplete_input: false, .. }) => {}
         Err(_) => panic!("error is not LuaSyntaxError::Syntax kind"),
         _ => panic!("error not returned"),
     }
     match lua.eval::<()>("function i_will_finish_what_i()", None) {
-        Err(Error::IncompleteStatement(_)) => {}
+        Err(Error::SyntaxError { incomplete_input: true, .. }) => {}
         Err(_) => panic!("error is not LuaSyntaxError::IncompleteStatement kind"),
         _ => panic!("error not returned"),
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -501,7 +501,7 @@ fn test_error() {
         _ => panic!("error not returned"),
     }
     match rust_error.call::<_, ()>(()) {
-        Err(Error::CallbackError(_, _)) => {}
+        Err(Error::CallbackError { .. }) => {}
         Err(_) => panic!("error is not CallbackError kind"),
         _ => panic!("error not returned"),
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -385,11 +385,12 @@ pub unsafe fn pcall_with_traceback(
             ffi::lua_remove(state, -2);
         } else if !is_wrapped_panic(state, 1) {
             let s = ffi::lua_tolstring(state, 1, ptr::null_mut());
-            if !s.is_null() {
-                ffi::luaL_traceback(state, state, s, 0);
+            let s = if s.is_null() {
+                cstr!("<unprintable Rust panic>")
             } else {
-                ffi::luaL_traceback(state, state, cstr!("<unprintable lua error>"), 0);
-            }
+                s
+            };
+            ffi::luaL_traceback(state, state, s, 0);
             ffi::lua_remove(state, -2);
         }
         1

--- a/src/util.rs
+++ b/src/util.rs
@@ -380,7 +380,10 @@ pub unsafe fn pcall_with_traceback(
                 .to_str()
                 .unwrap_or_else(|_| "<could not capture traceback>")
                 .to_owned();
-            push_wrapped_error(state, Error::CallbackError(traceback, Arc::new(error)));
+            push_wrapped_error(state, Error::CallbackError {
+                traceback,
+                cause: Arc::new(error),
+            });
             ffi::lua_remove(state, -2);
         } else if !is_wrapped_panic(state, 1) {
             let s = ffi::lua_tolstring(state, 1, ptr::null_mut());
@@ -415,7 +418,10 @@ pub unsafe fn resume_with_traceback(
                 .to_str()
                 .unwrap_or_else(|_| "<could not capture traceback>")
                 .to_owned();
-            push_wrapped_error(state, Error::CallbackError(traceback, Arc::new(error)));
+            push_wrapped_error(state, Error::CallbackError {
+                traceback,
+                cause: Arc::new(error),
+            });
             ffi::lua_remove(state, -2);
         } else if !is_wrapped_panic(state, 1) {
             let s = ffi::lua_tolstring(state, 1, ptr::null_mut());

--- a/src/util.rs
+++ b/src/util.rs
@@ -376,8 +376,7 @@ pub unsafe fn pcall_with_traceback(
         if let Some(error) = pop_wrapped_error(state) {
             ffi::luaL_traceback(state, state, ptr::null(), 0);
             let traceback = CStr::from_ptr(ffi::lua_tolstring(state, -1, ptr::null_mut()))
-                .to_str()
-                .unwrap_or_else(|_| "<could not capture traceback>")
+                .to_string_lossy()
                 .to_owned();
             push_wrapped_error(state, Error::CallbackError {
                 traceback,

--- a/src/util.rs
+++ b/src/util.rs
@@ -288,10 +288,11 @@ pub unsafe fn handle_error(state: *mut ffi::lua_State, err: c_int) -> Result<()>
                     }
                 }
                 ffi::LUA_ERRERR => {
-                    // This can only happen when rlua's own message handler raises an error, which
-                    // should never happen unless there's a bug. This would also be dangerous as it
-                    // longjmps over Rust frames.
-                    lua_panic!(state, "message handler raised error: {}", err_string);
+                    // The Lua manual documents this error wrongly: It is not raised when a message
+                    // handler errors, but rather when some specific situations regarding stack
+                    // overflow handling occurs. Since it is not very useful do differentiate
+                    // between that and "ordinary" runtime errors, we handle them the same way.
+                    Error::RuntimeError(err_string)
                 }
                 ffi::LUA_ERRMEM => {
                     // This is not impossible to hit, but this library is not set up

--- a/src/util.rs
+++ b/src/util.rs
@@ -377,7 +377,7 @@ pub unsafe fn pcall_with_traceback(
             ffi::luaL_traceback(state, state, ptr::null(), 0);
             let traceback = CStr::from_ptr(ffi::lua_tolstring(state, -1, ptr::null_mut()))
                 .to_string_lossy()
-                .to_owned();
+                .into_owned();
             push_wrapped_error(state, Error::CallbackError {
                 traceback,
                 cause: Arc::new(error),

--- a/src/util.rs
+++ b/src/util.rs
@@ -501,10 +501,7 @@ pub unsafe fn push_wrapped_error(state: *mut ffi::lua_State, err: Error) {
             Ok(1)
 
         } else {
-            Err(Error::FromLuaConversionError(
-                "internal error: userdata mismatch in Error metamethod"
-                    .to_owned(),
-            ))
+            panic!("internal error: userdata mismatch in Error metamethod");
         })
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -287,7 +287,12 @@ pub unsafe fn handle_error(state: *mut ffi::lua_State, err: c_int) -> Result<()>
                         message: err_string,
                     }
                 }
-                ffi::LUA_ERRERR => Error::ErrorError(err_string),
+                ffi::LUA_ERRERR => {
+                    // This can only happen when rlua's own message handler raises an error, which
+                    // should never happen unless there's a bug. This would also be dangerous as it
+                    // longjmps over Rust frames.
+                    lua_panic!(state, "message handler raised error: {}", err_string);
+                }
                 ffi::LUA_ERRMEM => {
                     // This is not impossible to hit, but this library is not set up
                     // to handle this properly.  Lua does a longjmp on out of memory


### PR DESCRIPTION
I'm not completely happy with the result, but the error messages ought to be a lot better now (still have to add tests for that). In particular, the conversion error variants are a bit too overloaded for my taste. Maybe I should remove a field from them.

Not sure if all of these changes are uncontroversial :)

Also, I'd like to remove the `ErrorError` variant. It *should* only happen if rlua's own message handler throws an error, which cannot happen. The handler *does* invoke a function that can error, `luaL_tolstring`, but only on wrapped errors and panics, where rlua controls the `__tostring` metamethod and ensures that it cannot panic. Is that correct?