### PR TITLE
Deny warnings on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rust:
   - stable
   - beta
   - nightly
+env:
+  - RUSTFLAGS="-D warnings"
 matrix:
   allow_failures:
     - rust: nightly


### PR DESCRIPTION
Always treating warnings as errors makes development annoying ("ugh I don't want to fix this right now"), but ignoring them quickly leaves them unfixed and shines a bad light on the project when other people want build it ("hmm, this crate's a little to... yellow for my taste"). I've found that this is pretty much a perfect middle ground (even though rlua doesn't require CI to pass before merging PRs).