### PR TITLE
Fix links in `Variadic` docs

### DIFF
--- a/src/multi.rs
+++ b/src/multi.rs
@@ -77,6 +77,9 @@ impl<'lua> FromLuaMulti<'lua> for MultiValue<'lua> {
 /// #     try_main().unwrap();
 /// # }
 /// ```
+///
+/// [`FromLua`]: trait.FromLua.html
+/// [`MultiValue`]: struct.MultiValue.html
 #[derive(Debug, Clone)]
 pub struct Variadic<T>(Vec<T>);
 


### PR DESCRIPTION
I forgot those in #43, sorry. It's a bit unsettling that rustdoc didn't complain.