### PR TITLE
Added ability to load debug lib, Fixes #52

### DIFF
--- a/src/lua.rs
+++ b/src/lua.rs
@@ -563,6 +563,7 @@ impl Lua {
     /// the guarantees of rlua.
     pub unsafe fn load_debug(&self) {
         ffi::luaL_requiref(self.state, cstr!("debug"), ffi::luaopen_debug, 1);
+        ffi::lua_pop(self.state, 1);
     }
 
     /// Loads a chunk of Lua code and returns it as a function.

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -557,6 +557,14 @@ impl Lua {
         }
     }
 
+    /// Loads the Lua debug library.
+    ///
+    /// The debug library is very unsound, loading it and using it breaks all
+    /// the guarantees of rlua.
+    pub unsafe fn load_debug(&self) {
+        ffi::luaL_requiref(self.state, cstr!("debug"), ffi::luaopen_debug, 1);
+    }
+
     /// Loads a chunk of Lua code and returns it as a function.
     ///
     /// The source can be named by setting the `name` parameter. This is generally recommended as it

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -562,6 +562,7 @@ impl Lua {
     /// The debug library is very unsound, loading it and using it breaks all
     /// the guarantees of rlua.
     pub unsafe fn load_debug(&self) {
+        check_stack(self.state, 1);
         ffi::luaL_requiref(self.state, cstr!("debug"), ffi::luaopen_debug, 1);
         ffi::lua_pop(self.state, 1);
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -15,6 +15,23 @@ fn test_load() {
 }
 
 #[test]
+fn test_load_debug() {
+    let lua = Lua::new();
+    lua.eval::<()>("debug", None).unwrap();
+    unsafe {
+        lua.load_debug();
+    }
+    match lua.eval("debug", None).unwrap() {
+        Value::Table(_) => {},
+        val => {
+            panic!("Expected table for debug library, got {:#?}", val)
+        }
+    }
+    let traceback_output = lua.eval::<String>("debug.traceback()", None).unwrap();
+    assert_eq!(traceback_output.split("\n").next(), "stack traceback:".into());
+}
+
+#[test]
 fn test_exec() {
     let lua = Lua::new();
     let globals = lua.globals();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,7 +17,7 @@ fn test_load() {
 #[test]
 fn test_load_debug() {
     let lua = Lua::new();
-    lua.eval::<()>("debug", None).unwrap();
+    lua.exec::<()>("assert(debug == nil)", None).unwrap();
     unsafe {
         lua.load_debug();
     }


### PR DESCRIPTION
Adds unsafe method `load_debug` to `Lua` that allows loading of the debug library. Marked it unsafe and added scary text to dissuade users from using it.