### PR TITLE
Fixes error when setting metatable to nil

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -629,6 +629,16 @@ fn test_recursive_callback_panic() {
         .unwrap();
 }
 
+#[test]
+fn test_set_metatable_nil() {
+    let lua = Lua::new();
+    lua.exec::<()>(
+    r#"
+        a = {}
+        setmetatable(a, nil)
+    "#, None).unwrap();
+}
+
 // TODO: Need to use compiletest-rs or similar to make sure these don't compile.
 /*
 #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -512,7 +512,7 @@ pub unsafe extern "C" fn safe_setmetatable(state: *mut ffi::lua_State) -> c_int 
     // Wrapping the __gc method in setmetatable ONLY works because Lua 5.3 only honors the __gc
     // method when it exists upon calling setmetatable, and ignores it if it is set later.
     push_string(state, "__gc");
-    if ffi::lua_rawget(state, -2) == ffi::LUA_TFUNCTION {
+    if ffi::lua_istable(state, -2) == 1 && ffi::lua_rawget(state, -2) == ffi::LUA_TFUNCTION {
         unsafe extern "C" fn safe_gc(state: *mut ffi::lua_State) -> c_int {
             ffi::lua_pushvalue(state, ffi::lua_upvalueindex(1));
             ffi::lua_insert(state, 1);


### PR DESCRIPTION
If you set the metatable to nil, currently it tries to get the `__gc` method without first checking whether or not the metatable is defined.

This fixes the issues I raised in #52 