### PR TITLE
Experimentally use the `failure` crate for errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ builtin-lua = ["gcc"]
 
 [dependencies]
 libc = { version = "0.2" }
+failure = { version = "0.1.1" }
 
 [build-dependencies]
 gcc = { version = "0.3.52", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,8 @@
 // warnings at all.
 #![doc(test(attr(deny(warnings))))]
 
+#[cfg_attr(test, macro_use)]
+extern crate failure;
 extern crate libc;
 
 mod ffi;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -318,7 +318,7 @@ fn test_result_conversions() {
 
     let err = lua.create_function(|_, ()| {
         Ok(Err::<String, _>(
-            "only through failure can we succeed".to_lua_err(),
+            format_err!("only through failure can we succeed").to_lua_err(),
         ))
     }).unwrap();
     let ok = lua.create_function(|_, ()| Ok(Ok::<_, Error>("!".to_owned())))

--- a/src/userdata.rs
+++ b/src/userdata.rs
@@ -477,7 +477,7 @@ mod tests {
                     if index.to_str()? == "inner" {
                         Ok(data.0)
                     } else {
-                        Err("no such custom index".to_lua_err())
+                        Err(format_err!("no such custom index").to_lua_err())
                     }
                 });
             }


### PR DESCRIPTION
I understand this may be a controversial change, which is why I want to discuss this as a PR.

The situation that is driving this change is that internally, Chucklefish projects have migrated away from using the `error_chain` crate to the `failure` crate.  The easiest thing for me to do when only considering Chucklefish's needs would be to merge this PR as is, but the reasons behind it and the total available options are somewhat nuanced.

`rlua` is in a unique, more complicated situation than many other library crates because it must be at once both a consumer of error types from external code, and a producer of internal error types when interpreting Lua, and both of these errors must be possible to represent at the same time.  Also, errors should at minimum be Send, but since for technical reasons around giving the ability for Lua itself to handle errors, they also need to be Clone.  In order for `rlua::Error` to be both Send and Clone, external error types must be in an Arc, and so must ALSO be Sync.

So, the summary is that `rlua::Error` is `Send + Sync + Clone + 'static`, and wrapped external errors must be `Send + Sync + 'static`.  This actually makes the current situation when using the `error_chain` crate problematic, because I believe only version 0.8 of `error_chain` produces Sync errors.  Chucklefish has a patched version of `error_chain` just for this problem, but again we're transitioning away from `error_chain` entirely anyway.

When using the `failure` crate with `rlua`, we ran into a different set of issues.  Inter-operating with `std::error::Error` style errors with `failure` is actually fairly well supported, with an included `Compat` wrapper to produce a `std::error::Error` compatible error from a `failure` type error.  The one caveat here is that the `Compat` wrapper type does not and cannot return a cause in `Error::cause`, which means that a long chain of errors will always stop at the first `failure::Fail` -> `std::error::Error` boundary.  Similarly, all types that are `std::error::Error + Send + Sync + 'static` implement `failure::Fail`, but again since it is impossible for them to return a `failure::Fail::cause`, a  chain of errors will also stop on a transition from `std::error::Error` to `failure::Fail`.  Code using `rlua` is quite likely to end up with "error sandwiches" where error types go from being external (in callbacks) to `rlua::Error`, and eventually back to being some external error type in the application using `rlua`, so these annoying limitations on the transition layers are particularly problematic.

For Chucklefish, using the `failure` crate is quite attractive; the pattern of using custom `failure::Fail` types for small errors and quickly transitioning to `failure::Error` for large application level errors simplifies error handling immensely without reducing any error handling power that we would realistically use.  With this change, either small local errors which implement `failure::Fail`, or large integrated errors `failure::Error` both can be wrapped as an external `rlua::Error`, and since `rlua::Error` also implements `failure::Fail`, there are no breaks in the cause chain.  Additionally, `failure::Error` is a huge performance improvement over the giant trees of enums that `error_chain` tends to produce.

For other people using `rlua` that are not necessarily using `failure`, there are two downsides.  One is that `rlua::Error` no longer can implement `std::error::Error` due to a conflicting impl of `failure::Fail`.  The other is that though `std::error::Error`s can be wrapped as external errors if they are also `Send + Sync + 'static` (same as now), doing so breaks the cause chain.

Are these downsides enough that this is an unacceptable change?  Is there a change that can make this inter-operate with both people using `std::error::Error` AND `failure`?  Should this be behind a feature flag?