### PR TITLE
Bump version to 0.20.1 and add deprecation status.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.20.1]
+- Add "deprecated" badge
+
+## [0.20.0]
+- Switch to being a wrapper around mlua
+
 ## [0.19.8]
 - Update rustyline dev-dependency (thanks @salexan2001)
 - Fix builds for iOS (thanks @w-ensink)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlua"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["kyren <kerriganw@gmail.com>"]
 edition = "2018"
 description = "High level bindings to Lua 5.x"
@@ -14,6 +14,9 @@ rust-version = "1.75"
 
 [badges]
 circle-ci = { repository = "mlua-rs/rlua", branch = "master" }
+
+[badges.maintenance]
+status = "deprecated"
 
 [dependencies]
 mlua = { version = "0.9.5", features = ["macros"] }


### PR DESCRIPTION
This should stop the libs.rs dashboard from complaining about things like using an old edition.